### PR TITLE
feat: add Android scaffold with SEC-005 security hardening

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,6 +36,19 @@ will become more meaningful when leaderboards are added (see §2).
 
 **Note**: If leaderboards are added (post-V1), SEC-008 risk level rises to MEDIUM. Server-side score validation will be required at that point — see §2.
 
+### 1.2 Android Platform Security Controls (SEC-005)
+
+The following declarative controls are configured in the `android/` scaffold:
+
+| Control | File | Value |
+|---------|------|-------|
+| Cleartext HTTP blocked | `android/app/src/main/AndroidManifest.xml` | `android:usesCleartextTraffic="false"` |
+| Network security config | `android/app/src/main/res/xml/network_security_config.xml` | `cleartextTrafficPermitted="false"`, system CA trust-anchors |
+| Backup disabled | `android/app/src/main/AndroidManifest.xml` | `android:allowBackup="false"` |
+| Minimum SDK | `android/app/build.gradle.kts` | `minSdk = 26` (Android 8.0+) |
+
+INTERNET permission is scoped to `debug/` and `profile/` manifests only; it is absent from the main manifest and therefore excluded from release APKs.
+
 ---
 
 ## 2. Scope of This Document
@@ -92,11 +105,11 @@ Choose **Supabase Auth** if:
 
 ### 4.1 Background
 
-Android 9+ (API 28+) blocks cleartext HTTP by default. Since `minSdk = 26` (Android 8), the app spans both behaviours. A `network_security_config.xml` must be created when any network calls are added.
+Android 9+ (API 28+) blocks cleartext HTTP by default. Since `minSdk = 26` (Android 8), the app spans both behaviours. `network_security_config.xml` is implemented as part of SEC-005 — cleartext traffic is blocked and only system CAs are trusted. When network calls are added (post-V1), extend §4.2 with domain-config certificate pinning.
 
-### 4.2 Network Security Config Template
+### 4.2 Network Security Config (Implemented — extend when adding backend)
 
-Create `android/app/src/main/res/xml/network_security_config.xml`:
+`android/app/src/main/res/xml/network_security_config.xml` is already in place:
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
@@ -346,7 +359,7 @@ Complete all items before shipping any backend-connected release:
 |---|---|---|
 | 1 | Production keystore generated and stored securely (not in repo) | [ ] |
 | 2 | `key.properties` created and gitignored | [ ] |
-| 3 | `network_security_config.xml` created with cleartext blocked | [ ] |
+| 3 | `network_security_config.xml` created with cleartext blocked | [x] Done in SEC-005 |
 | 4 | Auth provider selected and integrated (Firebase or Supabase) | [ ] |
 | 5 | Auth tokens stored via `flutter_secure_storage` | [ ] |
 | 6 | Rate limiting configured on all API endpoints | [ ] |

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -1,0 +1,7 @@
+gradle-wrapper.jar
+/.gradle
+/captures/
+/local.properties
+GeneratedPluginRegistrant.java
+*.jks
+*.keystore

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,0 +1,38 @@
+plugins {
+    id("com.android.application")
+    id("kotlin-android")
+    id("dev.flutter.flutter-gradle-plugin")
+}
+
+android {
+    namespace = "com.example.cosmic_match"
+    compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_17.toString()
+    }
+
+    defaultConfig {
+        applicationId = "com.example.cosmic_match"
+        minSdk = 26       // Android 8.0 — matches PRD §12 "Android 8+" requirement
+        targetSdk = 35    // Latest stable Android SDK
+        versionCode = flutter.versionCode
+        versionName = flutter.versionName
+    }
+
+    buildTypes {
+        release {
+            signingConfig = signingConfigs.getByName("debug")
+        }
+    }
+}
+
+flutter {
+    source = "../.."
+}

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -21,13 +21,15 @@ android {
     defaultConfig {
         applicationId = "com.example.cosmic_match"
         minSdk = 26       // Android 8.0 — matches PRD §12 "Android 8+" requirement
-        targetSdk = 35    // Latest stable Android SDK
+        targetSdk = 35
         versionCode = flutter.versionCode
         versionName = flutter.versionName
     }
 
     buildTypes {
         release {
+            // TODO(SEC): Replace with a proper release signing config before Play Store submission.
+            // See: https://developer.android.com/studio/publish/app-signing
             signingConfig = signingConfigs.getByName("debug")
         }
     }

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- INTERNET permission for Flutter tooling (hot reload, DevTools).
+         Scoped to debug builds only — not included in release APK. -->
+    <uses-permission android:name="android.permission.INTERNET"/>
+</manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -27,5 +27,6 @@
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
-    <!-- No <uses-permission> tags: game requires zero dangerous permissions -->
+    <!-- No <uses-permission> tags: release APK requests zero permissions.
+         INTERNET is restricted to debug/ and profile/ manifests only. -->
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:label="cosmic_match"
+        android:name="${applicationName}"
+        android:allowBackup="false"
+        android:usesCleartextTraffic="false"
+        android:networkSecurityConfig="@xml/network_security_config"
+        android:icon="@mipmap/ic_launcher">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:launchMode="singleTop"
+            android:taskAffinity=""
+            android:theme="@style/LaunchTheme"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
+            android:hardwareAccelerated="true"
+            android:windowSoftInputMode="adjustResize">
+            <meta-data
+                android:name="io.flutter.embedding.android.NormalTheme"
+                android:resource="@style/NormalTheme"/>
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
+    </application>
+    <!-- No <uses-permission> tags: game requires zero dangerous permissions -->
+</manifest>

--- a/android/app/src/main/kotlin/com/example/cosmic_match/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/cosmic_match/MainActivity.kt
@@ -1,0 +1,5 @@
+package com.example.cosmic_match
+
+import io.flutter.embedding.android.FlutterActivity
+
+class MainActivity: FlutterActivity()

--- a/android/app/src/main/res/drawable-v21/launch_background.xml
+++ b/android/app/src/main/res/drawable-v21/launch_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="?android:colorBackground" />
+</layer-list>

--- a/android/app/src/main/res/drawable/launch_background.xml
+++ b/android/app/src/main/res/drawable/launch_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="?android:colorBackground" />
+</layer-list>

--- a/android/app/src/main/res/values-night/styles.xml
+++ b/android/app/src/main/res/values-night/styles.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="LaunchTheme" parent="@android:style/Theme.Black.NoTitleBar">
+        <item name="android:windowBackground">@drawable/launch_background</item>
+    </style>
+    <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
+        <item name="android:windowBackground">?android:colorBackground</item>
+    </style>
+</resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="LaunchTheme" parent="@android:style/Theme.Black.NoTitleBar">
+        <item name="android:windowBackground">@drawable/launch_background</item>
+    </style>
+    <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
+        <item name="android:windowBackground">?android:colorBackground</item>
+    </style>
+</resources>

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- Block all cleartext HTTP; trust only system certificate authorities.
+         Pre-positioned for certificate pinning in a future release when the
+         game adds a server/leaderboard backend. -->
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/android/app/src/profile/AndroidManifest.xml
+++ b/android/app/src/profile/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- INTERNET permission for Dart VM service.
+         Scoped to profile builds only — not included in release APK. -->
+    <uses-permission android:name="android.permission.INTERNET"/>
+</manifest>

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,0 +1,18 @@
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.buildDir = file("../build")
+subprojects {
+    project.buildDir = file("${rootProject.buildDir}/${project.name}")
+}
+subprojects {
+    project.evaluationDependsOn(":app")
+}
+
+tasks.register<Delete>("clean") {
+    delete(rootProject.buildDir)
+}

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -5,14 +5,14 @@ allprojects {
     }
 }
 
-rootProject.buildDir = file("../build")
+rootProject.layout.buildDirectory.set(file("../build"))
 subprojects {
-    project.buildDir = file("${rootProject.buildDir}/${project.name}")
+    layout.buildDirectory.set(rootProject.layout.buildDirectory.dir(project.name))
 }
 subprojects {
     project.evaluationDependsOn(":app")
 }
 
 tasks.register<Delete>("clean") {
-    delete(rootProject.buildDir)
+    delete(rootProject.layout.buildDirectory)
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx4G -XX:+HeapDumpOnOutOfMemoryError
+android.useAndroidX=true
+android.enableJetifier=false

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -1,0 +1,25 @@
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
+
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
+
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.11.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
+}
+
+include ":app"

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -1,11 +1,14 @@
 pluginManagement {
-    def flutterSdkPath = {
-        def properties = new Properties()
-        file("local.properties").withInputStream { properties.load(it) }
-        def flutterSdkPath = properties.getProperty("flutter.sdk")
-        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-        return flutterSdkPath
-    }()
+    val flutterSdkPath: String = run {
+        val propsFile = file("local.properties")
+        require(propsFile.exists()) {
+            "local.properties not found. Run `flutter pub get` or set flutter.sdk manually."
+        }
+        val properties = java.util.Properties()
+        propsFile.inputStream().use { properties.load(it) }
+        properties.getProperty("flutter.sdk")
+            ?: error("flutter.sdk not set in local.properties")
+    }
 
     includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
@@ -17,9 +20,9 @@ pluginManagement {
 }
 
 plugins {
-    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.11.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
+    id("dev.flutter.flutter-plugin-loader") version "1.0.0"
+    id("com.android.application") version "8.11.1" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
 }
 
-include ":app"
+include(":app")


### PR DESCRIPTION
## Summary

Adds the missing `android/` platform scaffold with all five SEC-005 security controls enforced from the first build. Previously `flutter build apk --debug` failed entirely due to the absent Android directory.

**SEC-005 controls implemented:**
- `android:usesCleartextTraffic="false"` — defence-in-depth cleartext block at manifest level
- `network_security_config.xml` with `cleartextTrafficPermitted="false"` — primary NSC enforcement (API 24+), pre-positioned for certificate pinning
- `android:allowBackup="false"` — prevents Hive save files from being extracted via `adb backup`
- Zero `<uses-permission>` tags in `src/main/AndroidManifest.xml` — game requires no dangerous permissions
- `minSdk = 26` (Android 8.0+) — matches PRD §12; INTERNET permission scoped to `debug/` and `profile/` only

## Changes

| File | Action |
|------|--------|
| `android/.gitignore` | CREATE |
| `android/gradle/wrapper/gradle-wrapper.properties` | CREATE — Gradle 8.14 |
| `android/gradle.properties` | CREATE — `-Xmx4G` for CI compatibility |
| `android/settings.gradle.kts` | CREATE — AGP 8.11.1 + Kotlin 2.2.20 |
| `android/build.gradle.kts` | CREATE — top-level build file |
| `android/app/build.gradle.kts` | CREATE — `minSdk=26`, `targetSdk=35`, Java 17 |
| `android/app/src/main/AndroidManifest.xml` | CREATE — **SEC-005 hardened** |
| `android/app/src/main/res/xml/network_security_config.xml` | CREATE — **SEC-005 hardened** |
| `android/app/src/debug/AndroidManifest.xml` | CREATE — INTERNET for hot-reload |
| `android/app/src/profile/AndroidManifest.xml` | CREATE — INTERNET for Dart VM |
| `android/app/src/main/kotlin/com/example/cosmic_match/MainActivity.kt` | CREATE |
| `android/app/src/main/res/values/styles.xml` + 3 resource files | CREATE — splash screen |

No existing Dart/Flutter source files were modified.

## Validation

| Check | Result |
|-------|--------|
| `allowBackup="false"` in main manifest | ✅ |
| `usesCleartextTraffic="false"` in main manifest | ✅ |
| `cleartextTrafficPermitted="false"` in NSC | ✅ |
| Zero `<uses-permission>` in `src/main/` | ✅ |
| `minSdk = 26` in `app/build.gradle.kts` | ✅ |
| JVM heap `-Xmx4G` (not `-Xmx8G`) | ✅ |
| INTERNET permission only in `debug/` + `profile/` | ✅ |
| `flutter analyze` | ✅ No issues found |
| `flutter test` | ✅ 57/57 passed, 0 failed |

Fixes #5