### PR TITLE
feat: add SEC-002 Android release signing infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,3 +118,7 @@ jobs:
           name: release-aab
           path: build/app/outputs/bundle/release/app-release.aab
           retention-days: 30
+
+      - name: Clean up signing credentials
+        if: always()
+        run: rm -f android/cosmic-match-release.jks android/key.properties

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,51 @@ jobs:
           name: debug-apk
           path: build/app/outputs/flutter-apk/app-debug.apk
           retention-days: 7
+
+  release:
+    name: Release
+    needs: test
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          flutter-version: '3.41.0'
+          cache: true
+
+      - run: flutter pub get
+
+      - name: Decode keystore
+        env:
+          KEYSTORE_B64: ${{ secrets.KEYSTORE_BASE64 }}
+        run: printf '%s' "$KEYSTORE_B64" | base64 --decode > android/cosmic-match-release.jks
+
+      - name: Write key.properties
+        env:
+          STORE_PASSWORD: ${{ secrets.KEYSTORE_STORE_PASSWORD }}
+          KEY_PASSWORD: ${{ secrets.KEYSTORE_KEY_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEYSTORE_KEY_ALIAS }}
+        run: |
+          {
+            echo "storePassword=$STORE_PASSWORD"
+            echo "keyPassword=$KEY_PASSWORD"
+            echo "keyAlias=$KEY_ALIAS"
+            echo "storeFile=${{ github.workspace }}/android/cosmic-match-release.jks"
+          } > android/key.properties
+
+      - run: flutter build appbundle --release
+
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: release-aab
+          path: build/app/outputs/bundle/release/app-release.aab
+          retention-days: 30

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,9 @@ flutter test
 # Build (debug APK)
 flutter build apk --debug
 
+# Build (release AAB) — requires android/key.properties (see android/key.properties.example)
+flutter build appbundle --release
+
 # Generate Hive adapters (run after adding new Hive types)
 dart run build_runner build --delete-conflicting-outputs
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -105,9 +105,12 @@ Choose **Supabase Auth** if:
 
 Android 9+ (API 28+) blocks cleartext HTTP by default. Since `minSdk = 26` (Android 8), the app spans both behaviours. A `network_security_config.xml` must be created when any network calls are added.
 
-### 4.2 Network Security Config Template
+### 4.2 Network Security Config
 
-Create `android/app/src/main/res/xml/network_security_config.xml`:
+`android/app/src/main/res/xml/network_security_config.xml` is in place and blocks all
+cleartext traffic. It is referenced in `android/app/src/main/AndroidManifest.xml` via
+`android:networkSecurityConfig`. When backend API calls are added, extend the config
+with certificate pinning (template below):
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
@@ -301,13 +304,12 @@ Future<void> main() async {
 
 ### 8.1 Current State
 
-`android/app/build.gradle.kts` contains:
+Release signing is implemented via `android/app/build.gradle.kts`. When
+`android/key.properties` is present, the release build uses the configured keystore.
+When absent (local dev without a keystore), the release build falls back to debug signing.
 
-```kotlin
-// TODO: Add your own signing config for the release build.
-// Signing with the debug keys for now
-signingConfig = signingConfigs.getByName("debug")
-```
+See `android/key.properties.example` for the required file format, and §8.2 for keystore
+generation instructions.
 
 ### 8.2 Production Signing Requirements
 
@@ -331,35 +333,44 @@ Enrol in Google Play App Signing. This lets Google manage the app signing key wh
 
 ### 8.4 `build.gradle.kts` Signing Config (Kotlin DSL)
 
-Replace the debug signing placeholder in `android/app/build.gradle.kts` with the following. It reads `key.properties` for local development and falls back to environment variables for CI:
+The implemented config reads from `key.properties` only. The CI writes `key.properties`
+from secrets before running `flutter build` — **do not** add `System.getenv()` reads in
+Gradle, as those values can be captured in Gradle's configuration cache.
 
 ```kotlin
-// android/app/build.gradle.kts (release signing config template)
+// android/app/build.gradle.kts
 import java.util.Properties
+import java.io.FileInputStream
 
 val keyPropertiesFile = rootProject.file("key.properties")
-val keyProperties = Properties().apply {
-    if (keyPropertiesFile.exists()) load(keyPropertiesFile.inputStream())
+val keyProperties = Properties()
+if (keyPropertiesFile.exists()) {
+    keyProperties.load(FileInputStream(keyPropertiesFile))
 }
 
 android {
     signingConfigs {
         create("release") {
-            storeFile = file(
-                keyProperties["storeFile"] as String?
-                    ?: System.getenv("KEYSTORE_PATH") ?: error("No storeFile")
-            )
-            storePassword = keyProperties["storePassword"] as String?
-                ?: System.getenv("KEYSTORE_PASSWORD") ?: error("No storePassword")
-            keyAlias = keyProperties["keyAlias"] as String?
-                ?: System.getenv("KEY_ALIAS") ?: error("No keyAlias")
-            keyPassword = keyProperties["keyPassword"] as String?
-                ?: System.getenv("KEY_PASSWORD") ?: error("No keyPassword")
+            // Properties only set when key.properties exists.
+            // buildTypes.release falls back to debug signing when this block is empty.
+            if (keyPropertiesFile.exists()) {
+                keyAlias = keyProperties.getProperty("keyAlias")
+                    ?: error("keyAlias missing from android/key.properties — see key.properties.example")
+                keyPassword = keyProperties.getProperty("keyPassword")
+                    ?: error("keyPassword missing from android/key.properties")
+                storeFile = file(keyProperties.getProperty("storeFile")
+                    ?: error("storeFile missing from android/key.properties"))
+                storePassword = keyProperties.getProperty("storePassword")
+                    ?: error("storePassword missing from android/key.properties")
+            }
         }
     }
     buildTypes {
         release {
-            signingConfig = signingConfigs.getByName("release")
+            signingConfig = if (keyPropertiesFile.exists())
+                signingConfigs.getByName("release")
+            else
+                signingConfigs.getByName("debug")
         }
     }
 }
@@ -369,38 +380,47 @@ android {
 
 ### 8.5 GitHub Actions CI/CD Signing Snippet
 
-Add the following steps to your release job in `.github/workflows/release.yml`:
+The release job in `.github/workflows/ci.yml` implements signing as follows. Secrets are
+passed via `env:` blocks — **never** interpolated inline into `run:` scripts — to prevent
+exposure via process lists or logs.
 
 ```yaml
-# .github/workflows/release.yml (signing steps only — add to your release job)
+# .github/workflows/ci.yml (release job — signing steps)
 - name: Decode keystore
-  run: |
-    echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode \
-      > $RUNNER_TEMP/cosmic-match-release.jks
-
-- name: Build release APK
   env:
-    KEYSTORE_PATH: ${{ runner.temp }}/cosmic-match-release.jks
-    KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
-    KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
-    KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-  run: flutter build apk --release
+    KEYSTORE_B64: ${{ secrets.KEYSTORE_BASE64 }}
+  run: printf '%s' "$KEYSTORE_B64" | base64 --decode > android/cosmic-match-release.jks
 
-- name: Upload APK artifact
-  uses: actions/upload-artifact@v4
-  with:
-    name: release-apk
-    path: build/app/outputs/flutter-apk/app-release.apk
+- name: Write key.properties
+  env:
+    STORE_PASSWORD: ${{ secrets.KEYSTORE_STORE_PASSWORD }}
+    KEY_PASSWORD: ${{ secrets.KEYSTORE_KEY_PASSWORD }}
+    KEY_ALIAS: ${{ secrets.KEYSTORE_KEY_ALIAS }}
+  run: |
+    {
+      echo "storePassword=$STORE_PASSWORD"
+      echo "keyPassword=$KEY_PASSWORD"
+      echo "keyAlias=$KEY_ALIAS"
+      echo "storeFile=${{ github.workspace }}/android/cosmic-match-release.jks"
+    } > android/key.properties
+
+- run: flutter build appbundle --release
+
+- name: Clean up signing credentials
+  if: always()
+  run: rm -f android/cosmic-match-release.jks android/key.properties
 ```
+
+> Secrets are passed via `env:` blocks, never interpolated inline into `run:` scripts, to prevent exposure via process lists.
 
 **Required GitHub Secrets:**
 
 | Secret | Value |
 |--------|-------|
 | `KEYSTORE_BASE64` | **Linux:** `base64 -w 0 cosmic-match-release.jks` <br> **macOS:** `base64 cosmic-match-release.jks \| tr -d '\n'` |
-| `KEYSTORE_PASSWORD` | Store password |
-| `KEY_ALIAS` | `cosmic-match` |
-| `KEY_PASSWORD` | Key password |
+| `KEYSTORE_STORE_PASSWORD` | Store password |
+| `KEYSTORE_KEY_ALIAS` | `cosmic-match` |
+| `KEYSTORE_KEY_PASSWORD` | Key password |
 
 ### 8.6 Key Properties Example File
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -27,6 +27,8 @@ android {
 
     signingConfigs {
         create("release") {
+            // Properties only set when key.properties exists.
+            // buildTypes.release falls back to debug signing when this block is empty.
             if (keyPropertiesFile.exists()) {
                 keyAlias = keyProperties.getProperty("keyAlias")
                     ?: error("keyAlias missing from android/key.properties — see key.properties.example")

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,0 +1,55 @@
+import java.util.Properties
+import java.io.FileInputStream
+
+plugins {
+    id("com.android.application")
+    id("kotlin-android")
+    id("dev.flutter.flutter-gradle-plugin")
+}
+
+val keyPropertiesFile = rootProject.file("key.properties")
+val keyProperties = Properties()
+if (keyPropertiesFile.exists()) {
+    keyProperties.load(FileInputStream(keyPropertiesFile))
+}
+
+android {
+    namespace = "com.cosmicmatch.app"
+    compileSdk = flutter.compileSdkVersion
+
+    defaultConfig {
+        applicationId = "com.cosmicmatch.app"
+        minSdk = 26
+        targetSdk = flutter.targetSdkVersion
+        versionCode = flutter.versionCode
+        versionName = flutter.versionName
+    }
+
+    signingConfigs {
+        create("release") {
+            if (keyPropertiesFile.exists()) {
+                keyAlias = keyProperties.getProperty("keyAlias")
+                    ?: error("keyAlias missing from android/key.properties — see key.properties.example")
+                keyPassword = keyProperties.getProperty("keyPassword")
+                    ?: error("keyPassword missing from android/key.properties")
+                storeFile = file(keyProperties.getProperty("storeFile")
+                    ?: error("storeFile missing from android/key.properties"))
+                storePassword = keyProperties.getProperty("storePassword")
+                    ?: error("storePassword missing from android/key.properties")
+            }
+        }
+    }
+
+    buildTypes {
+        release {
+            signingConfig = if (keyPropertiesFile.exists())
+                signingConfigs.getByName("release")
+            else
+                signingConfigs.getByName("debug")
+        }
+    }
+}
+
+flutter {
+    source = "../.."
+}

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- INTERNET permission for Flutter tooling: hot reload, DevTools.
+         Only included in debug builds — not merged into release. -->
+    <uses-permission android:name="android.permission.INTERNET" />
+</manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,30 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:label="cosmic_match"
+        android:name="${applicationName}"
+        android:allowBackup="false"
+        android:usesCleartextTraffic="false"
+        android:networkSecurityConfig="@xml/network_security_config"
+        android:icon="@mipmap/ic_launcher">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:launchMode="singleTop"
+            android:taskAffinity=""
+            android:theme="@style/LaunchTheme"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
+            android:hardwareAccelerated="true"
+            android:windowSoftInputMode="adjustResize">
+            <meta-data
+                android:name="io.flutter.embedding.android.NormalTheme"
+                android:resource="@style/NormalTheme" />
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
+    </application>
+</manifest>

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,0 +1,6 @@
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G -XX:+HeapDumpOnOutOfMemoryError
+android.useAndroidX=true
+android.enableJetifier=true

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -1,0 +1,27 @@
+pluginManagement {
+    val flutterSdkPath = run {
+        val properties = java.util.Properties()
+        val localPropertiesFile = file("local.properties")
+        require(localPropertiesFile.exists()) {
+            "local.properties not found — run 'flutter pub get' or 'flutter build' first to generate it"
+        }
+        localPropertiesFile.inputStream().use { properties.load(it) }
+        val flutterSdkPath = properties.getProperty("flutter.sdk")
+        require(flutterSdkPath != null) { "flutter.sdk not set in local.properties" }
+        flutterSdkPath
+    }
+
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
+
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+plugins {
+    id("dev.flutter.flutter-gradle-plugin") version "1.0.0" apply false
+}
+
+include(":app")

--- a/lib/game/match3_game.dart
+++ b/lib/game/match3_game.dart
@@ -30,5 +30,4 @@ class Match3Game extends FlameGame<GridWorld> with RiverpodGameMixin {
     }
     _phase = next;
   }
-
 }

--- a/lib/game/world/grid_world.dart
+++ b/lib/game/world/grid_world.dart
@@ -34,7 +34,6 @@ class GridWorld extends World {
     // After maxAttempts, accept as-is; first game cycle will clear any matches
   }
 
-  /// Returns a random tile type using a proper RNG instance.
   TileType _randomTile() {
     return TileType.values[_rng.nextInt(TileType.values.length)];
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,8 +12,7 @@ Future<void> main() async {
   // AES-256 key in platform secure storage if not already present.
   // Returns null on platforms / emulators without secure storage (graceful degradation).
   // TODO(M2): capture cipher and pass to ProgressService via Riverpod provider.
-  // ignore: unused_local_variable
-  final cipher = await KeyService().getCipher();
+  await KeyService().getCipher();
   runApp(
     const ProviderScope(
       child: CosmicMatchApp(),


### PR DESCRIPTION
## Summary

- Adds the complete Android Gradle build scaffold required for signed Play Store distribution
- Extends the CI/CD pipeline with a `release` job that produces a signed AAB on pushes to `main`
- Implements SEC-005 hardening by blocking cleartext HTTP traffic via network security config

## Changes

### New Android build files
- `android/settings.gradle.kts` — root Gradle settings with Flutter SDK path resolution and actionable error messages
- `android/build.gradle.kts` — top-level `allprojects` repositories config
- `android/gradle.properties` — JVM heap settings, AndroidX and Jetifier flags
- `android/app/build.gradle.kts` — app module with `minSdk=26`, namespace `com.cosmicmatch.app`, and release signing config that reads `key.properties` when present, falls back to debug signing when absent
- `android/app/src/main/AndroidManifest.xml` — app manifest with `allowBackup="false"`, `usesCleartextTraffic="false"`, and `networkSecurityConfig` reference (SEC-005)
- `android/app/src/main/res/xml/network_security_config.xml` — blocks all cleartext HTTP; trusts system CA store only
- `android/app/src/debug/AndroidManifest.xml` — INTERNET permission for Flutter hot-reload (debug-only, not merged into release)

### CI/CD update
- `.github/workflows/ci.yml` — appended `release` job (SHA-pinned actions, Flutter 3.41.0) that decodes the keystore from `KEYSTORE_BASE64` secret via env var, writes `key.properties` via env vars (prevents shell metacharacter injection), builds the AAB, and uploads it as a 30-day artifact

## Security

- Secrets are passed through env vars, never inline in `run:` scripts, to prevent exposure via `/proc/cmdline`
- `*.jks` and `key.properties` are already gitignored — no secrets are committed
- Required GitHub Secrets (`KEYSTORE_BASE64`, `KEYSTORE_STORE_PASSWORD`, `KEYSTORE_KEY_PASSWORD`, `KEYSTORE_KEY_ALIAS`) must be configured by the repo admin as a separate manual step

## Validation

| Check | Result |
|-------|--------|
| All 7 Android files present | ✅ |
| CI `name: Release` job in ci.yml | ✅ |
| `flutter analyze` | ✅ No issues found |
| `flutter test` | ✅ 68/68 passed |
| `flutter build apk --debug` | ⚠️ Skipped — no Android SDK in this environment; runs in CI |

Fixes #2