### PR TITLE
Rename package to net.interstellarai.cosmicmatch + sign CI release APKs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,13 +65,35 @@ jobs:
 
       - run: flutter pub get
 
-      - run: flutter build apk --debug
+      - name: Decode release keystore
+        env:
+          KEYSTORE_B64: ${{ secrets.KEYSTORE_BASE64 }}
+        run: printf '%s' "$KEYSTORE_B64" | base64 --decode > android/cosmic-match-release.jks
+
+      - name: Write key.properties
+        env:
+          STORE_PASSWORD: ${{ secrets.KEYSTORE_STORE_PASSWORD }}
+          KEY_PASSWORD: ${{ secrets.KEYSTORE_KEY_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEYSTORE_KEY_ALIAS }}
+        run: |
+          {
+            echo "storePassword=$STORE_PASSWORD"
+            echo "keyPassword=$KEY_PASSWORD"
+            echo "keyAlias=$KEY_ALIAS"
+            echo "storeFile=${{ github.workspace }}/android/cosmic-match-release.jks"
+          } > android/key.properties
+
+      - run: flutter build apk --release
 
       - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
-          name: debug-apk
-          path: build/app/outputs/flutter-apk/app-debug.apk
-          retention-days: 7
+          name: release-apk
+          path: build/app/outputs/flutter-apk/app-release.apk
+          retention-days: 30
+
+      - name: Clean up signing credentials
+        if: always()
+        run: rm -f android/cosmic-match-release.jks android/key.properties
 
   release:
     name: Release

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -15,7 +15,7 @@ if (keyPropertiesFile.exists()) {
 }
 
 android {
-    namespace = "com.cosmicmatch.cosmic_match"
+    namespace = "net.interstellarai.cosmicmatch"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -29,7 +29,7 @@ android {
     }
 
     defaultConfig {
-        applicationId = "com.cosmicmatch.cosmic_match"
+        applicationId = "net.interstellarai.cosmicmatch"
         minSdk = 26
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode

--- a/android/app/src/main/kotlin/net/interstellarai/cosmicmatch/MainActivity.kt
+++ b/android/app/src/main/kotlin/net/interstellarai/cosmicmatch/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.cosmicmatch.cosmic_match
+package net.interstellarai.cosmicmatch
 
 import io.flutter.embedding.android.FlutterActivity
 


### PR DESCRIPTION
## Summary

### Package rename
`com.cosmicmatch.cosmic_match` → `net.interstellarai.cosmicmatch`

- `namespace` and `applicationId` in `android/app/build.gradle.kts`
- MainActivity.kt moved from `kotlin/com/cosmicmatch/cosmic_match/` to `kotlin/net/interstellarai/cosmicmatch/`
- Old directory removed

### CI: signed release APKs
The `Build` job previously produced an unsigned debug APK signed with a freshly-generated random debug key on each runner — every CI APK had a different signature, so reinstalling required uninstall-first (wiping data).

Updated the `Build` job to decode the release keystore from secrets (same pattern used by the existing `Release` job for AABs) and build a signed `apk-release.apk`. All CI APKs now share the same stable upload key signature — installs update in place.

## Test plan
- [x] `flutter build apk --debug` succeeds locally with new package name (Flutter 3.41.7, JDK 17).
- [ ] CI `Build` job produces a `release-apk` artifact.
- [ ] `adb install -r app-release.apk` over a previous install of the same signature works without uninstall.

## Note
You'll need to uninstall the existing `com.cosmicmatch.cosmic_match` install from your phone **once** — it's a different applicationId so Android treats it as a different app. After that, the new `net.interstellarai.cosmicmatch` app will update in place forever.