### PR TITLE
Fix grid layout — anchor camera viewfinder to topLeft

### DIFF
--- a/lib/game/match3_game.dart
+++ b/lib/game/match3_game.dart
@@ -1,3 +1,4 @@
+import 'package:flame/components.dart';
 import 'package:flame/game.dart';
 import 'package:flame_riverpod/flame_riverpod.dart';
 import 'components/grid_tile.dart';
@@ -19,6 +20,15 @@ class Match3Game extends FlameGame<GridWorld> with RiverpodGameMixin {
   final ProgressService? progressService;
 
   Match3Game({this.progressService}) : super(world: GridWorld());
+
+  @override
+  Future<void> onLoad() async {
+    await super.onLoad();
+    // Align world (0,0) with the top-left of the viewport so GridWorld's
+    // layout math (which computes positions relative to top-left) renders
+    // the board correctly instead of drifting into the bottom-right.
+    camera.viewfinder.anchor = Anchor.topLeft;
+  }
 
   GamePhase _phase = GamePhase.idle;
   GamePhase get phase => _phase;


### PR DESCRIPTION
## Summary
After PR #39 landed the playable game, the grid rendered in the bottom-right quadrant and was partially clipped.

Root cause: the default Flame camera anchors its viewfinder at world (0,0) = screen **center**. `GridWorld` computes `_boardOffset` and tile positions assuming world (0,0) = screen **top-left** (`(size.x - tileSize*cols)/2`, etc.). Result: every tile rendered half a screen diagonally off-position.

Fix: set `camera.viewfinder.anchor = Anchor.topLeft` in `Match3Game.onLoad`. No other code needed to change — `_boardOffset` already does the centering math.

## Test plan
- [x] `flutter build apk --debug` succeeds.
- [ ] Installed APK renders the 8×8 grid centered and fully visible on Pixel 8 Pro portrait.