### PR TITLE
Force JVM 17 via allprojects + plugins.withId (properly fixes sentry_flutter)

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -3,6 +3,36 @@ allprojects {
         google()
         mavenCentral()
     }
+
+    // Force JVM 17 everywhere — app + every plugin subproject (including
+    // sentry_flutter, which ships with Java 1.8 defaults). Uses reactive
+    // plugins.withId and task-type filters so config applies regardless
+    // of when the target plugin is applied.
+    plugins.withId("com.android.library") {
+        extensions.configure<com.android.build.gradle.LibraryExtension> {
+            compileOptions {
+                sourceCompatibility = JavaVersion.VERSION_17
+                targetCompatibility = JavaVersion.VERSION_17
+            }
+        }
+    }
+    plugins.withId("com.android.application") {
+        extensions.configure<com.android.build.gradle.AppExtension> {
+            compileOptions {
+                sourceCompatibility = JavaVersion.VERSION_17
+                targetCompatibility = JavaVersion.VERSION_17
+            }
+        }
+    }
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+        compilerOptions {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        }
+    }
+    tasks.withType<JavaCompile>().configureEach {
+        sourceCompatibility = JavaVersion.VERSION_17.toString()
+        targetCompatibility = JavaVersion.VERSION_17.toString()
+    }
 }
 
 val newBuildDir: Directory =


### PR DESCRIPTION
Tighter replacement for PR #45 which didn't stick. Locally verified with clean Flutter build: sentry_flutter compiles at JVM 17 end-to-end.