### PR TITLE
Add integration tests: scripted match-3 playthrough

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -151,3 +152,30 @@ jobs:
       - name: Clean up signing credentials
         if: always()
         run: rm -f android/cosmic-match-release.jks android/key.properties
+
+  integration:
+    name: Integration Tests
+    # macos-14 required for Android hardware acceleration
+    runs-on: macos-14
+    timeout-minutes: 30
+    # Only on main pushes or manual trigger — not PRs (emulator is slow/flaky)
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          flutter-version: '3.41.0'
+          cache: true
+
+      - uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          target: google_apis
+          arch: x86_64
+          script: flutter test integration_test/

--- a/integration_test/app_boot_test.dart
+++ b/integration_test/app_boot_test.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:flame_riverpod/flame_riverpod.dart';
+
+import 'package:cosmic_match/main.dart';
+import 'package:cosmic_match/game/match3_game.dart';
+import 'package:cosmic_match/services/progress_service.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('integ_boot_');
+    Hive.init(tempDir.path);
+  });
+
+  tearDown(() async {
+    await Hive.close();
+    await tempDir.delete(recursive: true);
+  });
+
+  testWidgets('app cold-starts and renders grid within 5 s',
+      (WidgetTester tester) async {
+    final progressService = ProgressService();
+    final game = Match3Game(progressService: progressService, rng: Random(0));
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: CosmicMatchApp(
+          progressService: progressService,
+          game: game,
+        ),
+      ),
+    );
+
+    // Allow up to 5 s for Flame to finish onLoad
+    await tester.pumpAndSettle(const Duration(seconds: 5));
+
+    expect(
+      find.byType(RiverpodAwareGameWidget<Match3Game>),
+      findsOneWidget,
+      reason: 'GameWidget must be present in the widget tree',
+    );
+  });
+}

--- a/integration_test/scripted_match_test.dart
+++ b/integration_test/scripted_match_test.dart
@@ -1,0 +1,85 @@
+import 'dart:io';
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:cosmic_match/main.dart';
+import 'package:cosmic_match/game/match3_game.dart';
+import 'package:cosmic_match/game/world/grid_world.dart';
+import 'package:cosmic_match/services/progress_service.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  late ProgressService progressService;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('integ_match_');
+    Hive.init(tempDir.path);
+    progressService = ProgressService();
+  });
+
+  tearDown(() async {
+    await Hive.close();
+    await tempDir.delete(recursive: true);
+  });
+
+  testWidgets(
+      'scripted swap produces score > 0, FSM returns to idle, score persists',
+      (WidgetTester tester) async {
+    // Seed 42 yields a board where swapping (0,0)↔(0,1) creates a 3-in-a-row.
+    // Verified offline. Change seed and update comment if Flutter stdlib RNG changes.
+    const boardSeed = 42;
+    final game =
+        Match3Game(progressService: progressService, rng: Random(boardSeed));
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: CosmicMatchApp(
+          progressService: progressService,
+          game: game,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle(const Duration(seconds: 5));
+
+    // Compute screen coordinates for tile centers (0,0) and (0,1).
+    final tileSize = game.world.tileSize;
+    final screenW = game.size.x;
+    final screenH = game.size.y;
+    const cols = GridWorld.cols;
+    const rows = GridWorld.rows;
+    final boardOffsetX = (screenW - tileSize * cols) / 2;
+    final boardOffsetY = 60.0 + (screenH - 60 - tileSize * rows) / 2;
+
+    Offset tileCenter(int x, int y) => Offset(
+          boardOffsetX + (x + 0.5) * tileSize,
+          boardOffsetY + (y + 0.5) * tileSize,
+        );
+
+    // Tap tile (0,0) to select, then (0,1) to trigger swap.
+    await tester.tapAt(tileCenter(0, 0));
+    await tester.pump();
+    await tester.tapAt(tileCenter(0, 1));
+
+    // Wait for cascade to settle (FSM: swapping → matching → falling → idle).
+    await tester.pumpAndSettle(const Duration(seconds: 10));
+
+    // Assert: score increased from zero.
+    expect(game.world.score.value, greaterThan(0),
+        reason: 'A 3-match must have cleared and awarded points');
+
+    // Assert: FSM returned to idle.
+    expect(game.phase, GamePhase.idle,
+        reason: 'Game must be ready for next interaction after cascade');
+
+    // Assert: progress was persisted — reload and check bestScore.
+    final loaded = await progressService.load(1);
+    expect(loaded.bestScore, greaterThan(0),
+        reason: 'Best score must be written to Hive after match');
+  });
+}

--- a/lib/game/match3_game.dart
+++ b/lib/game/match3_game.dart
@@ -1,3 +1,4 @@
+import 'dart:math';
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
 import 'package:flame_riverpod/flame_riverpod.dart';
@@ -19,7 +20,8 @@ const _validTransitions = <GamePhase, Set<GamePhase>>{
 class Match3Game extends FlameGame<GridWorld> with RiverpodGameMixin {
   final ProgressService? progressService;
 
-  Match3Game({this.progressService}) : super(world: GridWorld());
+  Match3Game({this.progressService, Random? rng})
+      : super(world: GridWorld(rng: rng));
 
   @override
   Future<void> onLoad() async {

--- a/lib/game/world/grid_world.dart
+++ b/lib/game/world/grid_world.dart
@@ -20,7 +20,9 @@ class GridWorld extends World {
   final Score score = Score();
   final CascadeController cascade = CascadeController();
   final PatternDetector detector = PatternDetector();
-  final _rng = Random();
+  final Random _rng;
+
+  GridWorld({Random? rng}) : _rng = rng ?? Random();
 
   // Logical grid — null means empty (tile is falling)
   late List<List<TileType?>> grid;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -48,8 +48,9 @@ Future<void> main() async {
 
 class CosmicMatchApp extends StatefulWidget {
   final ProgressService progressService;
+  final Match3Game? game; // @visibleForTesting — integration tests pass pre-built game
 
-  const CosmicMatchApp({super.key, required this.progressService});
+  const CosmicMatchApp({super.key, required this.progressService, this.game});
 
   @override
   State<CosmicMatchApp> createState() => _CosmicMatchAppState();
@@ -62,7 +63,7 @@ class _CosmicMatchAppState extends State<CosmicMatchApp> {
   @override
   void initState() {
     super.initState();
-    _game = Match3Game(progressService: widget.progressService);
+    _game = widget.game ?? Match3Game(progressService: widget.progressService);
   }
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -166,6 +166,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_driver:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -248,6 +253,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  fuchsia_remote_debug_protocol:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   glob:
     dependency: transitive
     description:
@@ -304,6 +314,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  integration_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   io:
     dependency: transitive
     description:
@@ -544,6 +559,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.5"
   pub_semver:
     dependency: transitive
     description:
@@ -669,6 +692,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -765,6 +796,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
   flutter_lints: ^4.0.0
 
 flutter:


### PR DESCRIPTION
## Summary

Adds Flutter integration test infrastructure and CI job to catch full-stack regressions that unit tests cannot detect — render crashes, FSM stuck states, and Hive save corruption.

## Changes

- **`pubspec.yaml`**: Add `integration_test: sdk: flutter` dev dependency
- **`lib/game/world/grid_world.dart`**: Inject optional `Random` via constructor (deterministic boards for tests)
- **`lib/game/match3_game.dart`**: Accept `Random? rng` and thread it through to `GridWorld`
- **`lib/main.dart`**: `CosmicMatchApp` accepts optional pre-built `Match3Game` for test injection
- **`integration_test/app_boot_test.dart`** _(new)_: Cold-start smoke test — verifies `RiverpodAwareGameWidget` renders within 5 s
- **`integration_test/scripted_match_test.dart`** _(new)_: Scripted swap at `(0,0)↔(0,1)` using seed 42; asserts `score > 0`, `phase == idle`, and `bestScore` persisted to Hive
- **`.github/workflows/ci.yml`**: New `integration` job on `macos-14` with API-34 Android emulator; gated to `main` pushes and `workflow_dispatch` only (not PRs — emulator boots are slow)

## Validation

| Check | Result |
|-------|--------|
| `flutter analyze` | ✅ No issues |
| `flutter test` (unit) | ✅ 88 passed, 0 failed |
| Integration tests | ⏭️ Require device/emulator — validated via CI on merge to main |

## Design Notes

- Production behaviour is unchanged — `CosmicMatchApp()` and `Match3Game()` work identically without arguments
- `Random` injection uses the existing constructor-param pattern; the unseeded `Random()` default preserves production randomness
- Integration job intentionally excluded from PR gates to avoid slow/flaky emulator blocking reviews; runs post-merge on `main`

Fixes #44