### PR TITLE
CI: bump Flutter to 3.41.7 (may unblock sentry_flutter JVM compat)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
-          flutter-version: '3.41.0'
+          flutter-version: '3.41.7'
           cache: true
 
       - run: flutter analyze
@@ -41,7 +41,7 @@ jobs:
 
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
-          flutter-version: '3.41.0'
+          flutter-version: '3.41.7'
           cache: true
 
       - run: flutter test
@@ -60,7 +60,7 @@ jobs:
 
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
-          flutter-version: '3.41.0'
+          flutter-version: '3.41.7'
           cache: true
 
       - run: flutter pub get
@@ -111,7 +111,7 @@ jobs:
 
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
-          flutter-version: '3.41.0'
+          flutter-version: '3.41.7'
           cache: true
 
       - run: flutter pub get


### PR DESCRIPTION
Local clean build with Flutter 3.41.7 + the allprojects JVM 17 fix from PR #48 succeeds. CI using 3.41.0 still fails with the same sentry_flutter JVM target mismatch. Bumping CI to 3.41.7 to match working local setup.