### PR TITLE
fix(android): use afterEvaluate for JVM 17 override on library subprojects

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -4,18 +4,6 @@ allprojects {
         mavenCentral()
     }
 
-    // Force JVM 17 everywhere — app + every plugin subproject (including
-    // sentry_flutter, which ships with Java 1.8 defaults). Uses reactive
-    // plugins.withId and task-type filters so config applies regardless
-    // of when the target plugin is applied.
-    plugins.withId("com.android.library") {
-        extensions.configure<com.android.build.gradle.LibraryExtension> {
-            compileOptions {
-                sourceCompatibility = JavaVersion.VERSION_17
-                targetCompatibility = JavaVersion.VERSION_17
-            }
-        }
-    }
     plugins.withId("com.android.application") {
         extensions.configure<com.android.build.gradle.AppExtension> {
             compileOptions {
@@ -48,15 +36,14 @@ subprojects {
 subprojects {
     project.evaluationDependsOn(":app")
 
-    // Force JVM 17 on every subproject so plugin-defined Android modules
-    // (e.g. sentry_flutter) don't fall back to Java 1.8 and break the
-    // build with "Inconsistent JVM-target compatibility" on release.
-    plugins.withId("com.android.library") {
-        extensions.configure<com.android.build.gradle.LibraryExtension> {
-            compileOptions {
-                sourceCompatibility = JavaVersion.VERSION_17
-                targetCompatibility = JavaVersion.VERSION_17
-            }
+    // afterEvaluate fires after the subproject's own build script has fully
+    // run, so this override wins over sentry_flutter's own compileOptions
+    // (which resets to Java 1.8). plugins.withId fires mid-evaluation and
+    // gets overridden — that's why PRs #45/#48 didn't stick.
+    afterEvaluate {
+        extensions.findByType<com.android.build.gradle.LibraryExtension>()?.compileOptions {
+            sourceCompatibility = JavaVersion.VERSION_17
+            targetCompatibility = JavaVersion.VERSION_17
         }
     }
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {


### PR DESCRIPTION
## Summary

- Replaces `plugins.withId("com.android.library")` in the `subprojects` block with `afterEvaluate`, so the JVM 17 `compileOptions` override fires *after* sentry_flutter's own build script has finished evaluating — preventing it from reasserting Java 1.8 and causing the `compileReleaseJavaWithJavac` / `compileReleaseKotlin` JVM target mismatch.
- Removes the now-redundant `plugins.withId("com.android.library")` block from `allprojects`, which had the same ordering flaw and was never effective.

## Root Cause

`plugins.withId` fires synchronously when the Android library plugin is applied (mid-evaluation). sentry_flutter's own `build.gradle` then runs and reasserts `compileOptions { targetCompatibility = JavaVersion.VERSION_1_8 }`, undoing our override. Previous fix attempts in #45 and #48 both used this same approach and failed for the same reason. `afterEvaluate` runs after the entire subproject build script completes, so our `targetCompatibility = VERSION_17` wins.

## Changes

| File | Action |
|------|--------|
| `android/build.gradle.kts` | `plugins.withId` → `afterEvaluate` in `subprojects`; removed redundant block from `allprojects` (+8/-21 lines) |

## Validation

- `flutter analyze` — no issues found
- `flutter test` — 88/88 passed

## Test Plan

- [ ] CI Build job passes `Gradle task assembleRelease` without the JVM target mismatch error
- [ ] `release-apk` artifact appears in the Actions run summary

Fixes #61