### PR TITLE
fix(android): guard afterEvaluate to skip :app project

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -40,6 +40,7 @@ subprojects {
     // run, so this override wins over sentry_flutter's own compileOptions
     // (which resets to Java 1.8). plugins.withId fires mid-evaluation and
     // gets overridden — that's why PRs #45/#48 didn't stick.
+    //
     // Skip :app — evaluationDependsOn(":app") above causes it to be evaluated
     // before this block runs for it, making afterEvaluate illegal on :app.
     // :app sets its own compileOptions directly in app/build.gradle.kts.

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -40,10 +40,15 @@ subprojects {
     // run, so this override wins over sentry_flutter's own compileOptions
     // (which resets to Java 1.8). plugins.withId fires mid-evaluation and
     // gets overridden — that's why PRs #45/#48 didn't stick.
-    afterEvaluate {
-        extensions.findByType<com.android.build.gradle.LibraryExtension>()?.compileOptions {
-            sourceCompatibility = JavaVersion.VERSION_17
-            targetCompatibility = JavaVersion.VERSION_17
+    // Skip :app — evaluationDependsOn(":app") above causes it to be evaluated
+    // before this block runs for it, making afterEvaluate illegal on :app.
+    // :app sets its own compileOptions directly in app/build.gradle.kts.
+    if (project.name != "app") {
+        afterEvaluate {
+            extensions.findByType<com.android.build.gradle.LibraryExtension>()?.compileOptions {
+                sourceCompatibility = JavaVersion.VERSION_17
+                targetCompatibility = JavaVersion.VERSION_17
+            }
         }
     }
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {


### PR DESCRIPTION
## Summary

- `android/build.gradle.kts`: wrap the `afterEvaluate` block in `subprojects {}` with `if (project.name != "app")` to prevent Gradle from registering a post-evaluation hook on an already-evaluated project.

## Root Cause

PR #64 (`bac04fd`) added an `afterEvaluate` block inside `subprojects {}` to override `sentry_flutter`'s library-level `compileOptions` (which resets to Java 1.8). The same block also calls `project.evaluationDependsOn(":app")` for every subproject. When the `subprojects` loop reaches `:app`, it is already fully evaluated (due to the `evaluationDependsOn` call), so Gradle throws:

```
Cannot run Project.afterEvaluate(Action) when the project is already evaluated
```

This broke both Build and Release CI jobs.

## Changes

| File | Action | Description |
|------|--------|-------------|
| `android/build.gradle.kts` | UPDATE (+9/-4) | Guard `afterEvaluate` with `if (project.name != "app")` |

`:app` is safe to skip — it already sets `compileOptions { sourceCompatibility/targetCompatibility = VERSION_17 }` directly in `android/app/build.gradle.kts:26-29`. All non-app library subprojects (including `sentry_flutter`) continue to receive the `afterEvaluate` override.

## Validation

| Check | Result |
|-------|--------|
| `flutter analyze` | ✅ No issues |
| `flutter test` | ✅ 88 tests passed, 0 failed |

Fixes #66