### PR TITLE
ci: exercise release build on PRs + tolerate broken keystore secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,6 @@ jobs:
   release:
     name: Release
     needs: test
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -119,34 +118,78 @@ jobs:
 
       - run: flutter pub get
 
-      - name: Decode keystore
+      # Resolve signing keystore: try the real release keystore from secrets;
+      # fall back to a CI-throwaway if the secret is missing or unreadable.
+      # This keeps the release build path exercised on every PR even when the
+      # real keystore is unavailable — catching regressions before merge to main.
+      # Artifact naming reflects which keystore produced the AAB.
+      - name: Resolve signing keystore
+        id: keystore
         env:
           KEYSTORE_B64: ${{ secrets.KEYSTORE_BASE64 }}
-        run: printf '%s' "$KEYSTORE_B64" | base64 --decode > android/cosmic-match-release.jks
-
-      - name: Write key.properties
-        env:
           STORE_PASSWORD: ${{ secrets.KEYSTORE_STORE_PASSWORD }}
           KEY_PASSWORD: ${{ secrets.KEYSTORE_KEY_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEYSTORE_KEY_ALIAS }}
         run: |
+          set -u
+          KS=android/cosmic-match-release.jks
+          USED_REAL=no
+          if [ -n "${KEYSTORE_B64:-}" ]; then
+            printf '%s' "$KEYSTORE_B64" | base64 --decode --ignore-garbage > "$KS" 2>/dev/null || true
+            if keytool -list -storetype PKCS12 -storepass "${STORE_PASSWORD:-}" -keystore "$KS" >/dev/null 2>&1 \
+               || keytool -list -storetype JKS    -storepass "${STORE_PASSWORD:-}" -keystore "$KS" >/dev/null 2>&1; then
+              echo "::notice ::Using real release keystore from KEYSTORE_BASE64"
+              USED_REAL=yes
+            else
+              echo "::warning ::KEYSTORE_BASE64 is set but the decoded file is not a readable keystore. Falling back to CI throwaway. The produced AAB will NOT be uploadable to Play Store."
+              rm -f "$KS"
+            fi
+          else
+            echo "::notice ::KEYSTORE_BASE64 not set (PR run or missing secret) — generating CI throwaway keystore"
+          fi
+
+          if [ "$USED_REAL" = "no" ]; then
+            keytool -genkey -v \
+              -keystore "$KS" \
+              -alias cosmic-match \
+              -keyalg RSA -keysize 2048 \
+              -validity 1 \
+              -storepass ci_build -keypass ci_build \
+              -dname "CN=CI Build" \
+              -storetype PKCS12
+            STORE_PASSWORD=ci_build
+            KEY_PASSWORD=ci_build
+            KEY_ALIAS=cosmic-match
+          fi
+
           {
             echo "storePassword=$STORE_PASSWORD"
             echo "keyPassword=$KEY_PASSWORD"
             echo "keyAlias=$KEY_ALIAS"
-            echo "storeFile=${{ github.workspace }}/android/cosmic-match-release.jks"
+            echo "storeFile=${{ github.workspace }}/$KS"
           } > android/key.properties
+          echo "used_real=$USED_REAL" >> "$GITHUB_OUTPUT"
 
       - name: Build release AAB
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: flutter build appbundle --release --dart-define=SENTRY_DSN=$SENTRY_DSN
 
-      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+      - name: Upload signed AAB
+        if: steps.keystore.outputs.used_real == 'yes'
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: release-aab
           path: build/app/outputs/bundle/release/app-release.aab
           retention-days: 30
+
+      - name: Upload CI-signed AAB (not for Play Store)
+        if: steps.keystore.outputs.used_real != 'yes'
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: release-aab-ci-throwaway
+          path: build/app/outputs/bundle/release/app-release.aab
+          retention-days: 7
 
       - name: Clean up signing credentials
         if: always()


### PR DESCRIPTION
## Why

Two bugs hiding each other on cosmic-match main:

1. The `release` job was gated to `push` on `main` only — PRs never exercised
   the signing/bundling path. Every archon fix PR saw green CI (Release job
   skipped), merged, and then failed on main with the same error. Archon had
   no feedback loop, so it kept landing ineffective patches against a moving
   SHA for hours.

2. `KEYSTORE_BASE64` currently decodes to an unreadable blob
   (`keytool`/BundleTool: "Tag number over 30 is not supported"). Needs to
   be rotated — tracked separately as a human-needed issue.

## What this PR does

- **Removes the push-to-main gate** on the release job → every PR exercises
  the full release-bundle build. Future Android/Gradle regressions are
  caught before merge.
- **Adds a keystore-resolve step** that tries the real keystore from secrets
  first, validates it with `keytool -list`, and falls back to a throwaway
  PKCS12 (the same pattern the `build` job already uses for APKs) if the
  secret is missing or unreadable. Main is green today with a throwaway;
  rotating the real keystore automatically flips it back to real signing
  with no workflow edit needed.
- **Splits the artifact upload** so real-signed AABs retain for 30 days
  under `release-aab` and CI-throwaway AABs retain for 7 days under
  `release-aab-ci-throwaway` — won't mistakenly upload a throwaway-signed
  AAB to Play Store.

## Test plan

- [ ] CI on this PR runs the new Release job end-to-end (should go green
      via throwaway fallback since the real keystore is broken)
- [ ] Log shows `::warning ::KEYSTORE_BASE64 is set but the decoded file
      is not a readable keystore. Falling back to CI throwaway.`
- [ ] Artifact uploaded as `release-aab-ci-throwaway`
- [ ] After merge, main CI goes green
- [ ] Once keystore is rotated, next main push produces `release-aab`
      under real signing with no further code change