### PR TITLE
ci: build signed APK on every main push, drop redundant CI-throwaway build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,57 +46,6 @@ jobs:
 
       - run: flutter test
 
-  build:
-    name: Build
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: temurin
-          java-version: '17'
-
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
-        with:
-          flutter-version: '3.41.7'
-          cache: true
-
-      - run: flutter pub get
-
-      - name: Generate CI signing key
-        run: |
-          keytool -genkey -v \
-            -keystore android/cosmic-match-release.jks \
-            -alias cosmic-match \
-            -keyalg RSA -keysize 2048 \
-            -validity 1 \
-            -storepass ci_build -keypass ci_build \
-            -dname "CN=CI Build" \
-            -storetype PKCS12
-          {
-            echo "storePassword=ci_build"
-            echo "keyPassword=ci_build"
-            echo "keyAlias=cosmic-match"
-            echo "storeFile=${{ github.workspace }}/android/cosmic-match-release.jks"
-          } > android/key.properties
-
-      - name: Build release APK
-        env:
-          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-        run: flutter build apk --release --dart-define=SENTRY_DSN=$SENTRY_DSN
-
-      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
-        with:
-          name: release-apk
-          path: build/app/outputs/flutter-apk/app-release.apk
-          retention-days: 30
-
-      - name: Clean up signing credentials
-        if: always()
-        run: rm -f android/cosmic-match-release.jks android/key.properties
-
   release:
     name: Release
     needs: test
@@ -175,6 +124,11 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: flutter build appbundle --release --dart-define=SENTRY_DSN=$SENTRY_DSN
 
+      - name: Build release APK
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+        run: flutter build apk --release --dart-define=SENTRY_DSN=$SENTRY_DSN
+
       - name: Upload signed AAB
         if: steps.keystore.outputs.used_real == 'yes'
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
@@ -183,12 +137,28 @@ jobs:
           path: build/app/outputs/bundle/release/app-release.aab
           retention-days: 30
 
+      - name: Upload signed APK
+        if: steps.keystore.outputs.used_real == 'yes'
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: release-apk
+          path: build/app/outputs/flutter-apk/app-release.apk
+          retention-days: 30
+
       - name: Upload CI-signed AAB (not for Play Store)
         if: steps.keystore.outputs.used_real != 'yes'
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: release-aab-ci-throwaway
           path: build/app/outputs/bundle/release/app-release.aab
+          retention-days: 7
+
+      - name: Upload CI-signed APK (not reinstallable over real builds)
+        if: steps.keystore.outputs.used_real != 'yes'
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: release-apk-ci-throwaway
+          path: build/app/outputs/flutter-apk/app-release.apk
           retention-days: 7
 
       - name: Clean up signing credentials


### PR DESCRIPTION
## Summary
- Release job now also produces a signed APK (alongside AAB) when real keystore secrets are present. \`KEYSTORE_BASE64\` et al. are now set on this repo, so every main push produces an APK installable on dev phones with in-place updates.
- Deletes the standalone \`Build\` job: it always used a CI-throwaway keystore and uploaded to the same \`release-apk\` artifact name the release job now uses. Fork PRs without secrets still get the throwaway fallback via distinct \`-ci-throwaway\` artifact names.

## Test plan
- [ ] On merge, the Release job triggers and uploads both \`release-aab\` and \`release-apk\` artifacts (real-signed).
- [ ] The APK installs cleanly on a test phone via \`adb install -r\`.
- [ ] Fork PR (simulated by clearing secrets) falls back to \`release-aab-ci-throwaway\` + \`release-apk-ci-throwaway\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)