### PR TITLE
feat: add swipe-to-swap tile input

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ flutter pub get
 ```
 lib/
   game/           # Flame game, FSM, world, components
+                  #   Input/FSM enums (GamePhase, SwipeDirection) defined in match3_game.dart
     theme/        # Tile color palette constants (kTilePalette — derived from TileType.colorValue;
                   #   kTileGlowPalette — derived from TileType.glowValue, used for selection border;
                   #   kTileSelectedOverlay — transparent, selection drawn by _GlowBorder stroke;
@@ -91,7 +92,7 @@ Four mitigations protect against trivial client-side manipulation (see SECURITY.
 
 | Control | Location | Behaviour |
 |---------|----------|-----------|
-| FSM Input Gate | `GridTile.onTapDown` | Drops all taps when `phase != idle` |
+| FSM Input Gate | `GridTile.onTapDown`, `GridTile.onDragStart` | Drops all tap and swipe input when `phase != idle` |
 | Score Clamp | `Score.add()` | Clamps to 999,999,999; ignores negative inputs |
 | Cascade Depth Limit | `CascadeController.increment()` | Caps at 20; no-op beyond max |
 | CRC32 Save Integrity | `LevelProgress.toMap()` / `ProgressService._isValid()` | Resets tampered save data |

--- a/lib/game/components/grid_tile.dart
+++ b/lib/game/components/grid_tile.dart
@@ -1,7 +1,7 @@
 import 'package:flame/components.dart';
 import 'package:flame/events.dart';
 import 'package:flame_riverpod/flame_riverpod.dart';
-import 'package:flutter/material.dart' show Canvas, Color, Colors, CustomPainter, Paint, PaintingStyle, RRect, Radius, Rect, visibleForTesting;
+import 'package:flutter/material.dart' show Canvas, Colors, CustomPainter, Paint, PaintingStyle, RRect, Radius, Rect, visibleForTesting;
 import '../../core/logger.dart';
 import '../../models/tile_type.dart';
 import '../match3_game.dart';
@@ -66,7 +66,7 @@ class GridTile extends RectangleComponent
     _painterReady = true;
 
     // Make the base rectangle transparent — tile body is drawn by the painter
-    paint.color = const Color(0x00000000);
+    paint.color = Colors.transparent;
   }
 
   void select() => _selected = true;

--- a/lib/game/components/grid_tile.dart
+++ b/lib/game/components/grid_tile.dart
@@ -2,6 +2,7 @@ import 'package:flame/components.dart';
 import 'package:flame/events.dart';
 import 'package:flame_riverpod/flame_riverpod.dart';
 import 'package:flutter/material.dart' show Canvas, Color, Colors, CustomPainter, Paint, PaintingStyle, RRect, Radius, Rect, visibleForTesting;
+import '../../core/logger.dart';
 import '../../models/tile_type.dart';
 import '../match3_game.dart';
 import '../theme/tile_palette.dart';
@@ -107,6 +108,23 @@ class GridTile extends RectangleComponent
     }
   }
 
+  /// Thin wrapper exposed for unit testing without a Flame engine.
+  /// Consistent with the [selectionBorderVisible] pattern in this file.
+  @visibleForTesting
+  SwipeDirection? dominantDirectionForTest(Vector2 delta, double threshold) =>
+      _dominantDirection(delta, threshold);
+
+  /// Restores all drag-mutated positions and clears drag state.
+  /// Called from every drag exit path to prevent tiles staying displaced.
+  void _resetDragState() {
+    _dragging = false;
+    position = _dragOriginPosition;
+    if (_dragPreviewNeighbor != null) {
+      _dragPreviewNeighbor!.position = _dragNeighborOrigin;
+      _dragPreviewNeighbor = null;
+    }
+  }
+
   @override
   void onDragStart(DragStartEvent event) {
     super.onDragStart(event);
@@ -138,17 +156,22 @@ class GridTile extends RectangleComponent
 
     // Preview neighbor tile (subtle counter-offset)
     final game = findGame() as Match3Game?;
-    if (game == null) return;
+    if (game == null) {
+      _resetDragState();
+      return;
+    }
     final neighborX = gridX + direction.dx;
     final neighborY = gridY + direction.dy;
     final neighbor = game.world.tileAt(neighborX, neighborY);
-    if (neighbor != null && neighbor != _dragPreviewNeighbor) {
-      // Restore previous neighbor if direction changed
+    // Restore previous neighbor whenever the target changes, including to null/OOB.
+    if (neighbor != _dragPreviewNeighbor) {
       if (_dragPreviewNeighbor != null) {
         _dragPreviewNeighbor!.position = _dragNeighborOrigin;
       }
       _dragPreviewNeighbor = neighbor;
-      _dragNeighborOrigin = neighbor.position.clone();
+      if (neighbor != null) {
+        _dragNeighborOrigin = neighbor.position.clone();
+      }
     }
     if (_dragPreviewNeighbor != null) {
       _dragPreviewNeighbor!.position = _dragNeighborOrigin - axisOffset * 0.3;
@@ -159,32 +182,26 @@ class GridTile extends RectangleComponent
   void onDragEnd(DragEndEvent event) {
     super.onDragEnd(event);
     if (!_dragging) return;
-    _dragging = false;
 
     // Snap tiles back to home positions before handing off to runSwap
     // (runSwap records position at start, so must be canonical first)
-    position = _dragOriginPosition;
-    if (_dragPreviewNeighbor != null) {
-      _dragPreviewNeighbor!.position = _dragNeighborOrigin;
-      _dragPreviewNeighbor = null;
-    }
+    _resetDragState();
 
     final direction = _dominantDirection(_accumulatedDelta, size.x * 0.3);
     if (direction == null) return; // too short — ignore
 
     final game = findGame() as Match3Game?;
-    game?.onTileSwipe(this, direction);
+    if (game == null) {
+      gameLogger.w('GridTile.onDragEnd: findGame() returned null — swap dropped');
+      return;
+    }
+    game.onTileSwipe(this, direction);
   }
 
   @override
   void onDragCancel(DragCancelEvent event) {
     super.onDragCancel(event);
     if (!_dragging) return;
-    _dragging = false;
-    position = _dragOriginPosition;
-    if (_dragPreviewNeighbor != null) {
-      _dragPreviewNeighbor!.position = _dragNeighborOrigin;
-      _dragPreviewNeighbor = null;
-    }
+    _resetDragState();
   }
 }

--- a/lib/game/components/grid_tile.dart
+++ b/lib/game/components/grid_tile.dart
@@ -8,7 +8,7 @@ import '../theme/tile_palette.dart';
 import 'tile_shape_painter.dart';
 
 class GridTile extends RectangleComponent
-    with TapCallbacks, RiverpodComponentMixin {
+    with TapCallbacks, DragCallbacks, RiverpodComponentMixin {
   int gridX;
   int gridY;
 
@@ -28,6 +28,13 @@ class GridTile extends RectangleComponent
 
   bool _painterReady = false;
   bool _selected = false;
+
+  // --- drag state (reset on each gesture) ---
+  bool _dragging = false;
+  Vector2 _dragOriginPosition = Vector2.zero();
+  Vector2 _accumulatedDelta = Vector2.zero();
+  GridTile? _dragPreviewNeighbor;
+  Vector2 _dragNeighborOrigin = Vector2.zero();
   late Paint _glowPaint;
   late CustomPainter _painter; // cached per-type — avoids per-frame allocation
 
@@ -89,5 +96,95 @@ class GridTile extends RectangleComponent
 
     game.onTileTap(this);
     event.handled = true;
+  }
+
+  SwipeDirection? _dominantDirection(Vector2 delta, double threshold) {
+    if (delta.length < threshold) return null;
+    if (delta.x.abs() >= delta.y.abs()) {
+      return delta.x > 0 ? SwipeDirection.right : SwipeDirection.left;
+    } else {
+      return delta.y > 0 ? SwipeDirection.down : SwipeDirection.up;
+    }
+  }
+
+  @override
+  void onDragStart(DragStartEvent event) {
+    super.onDragStart(event);
+    final game = findGame() as Match3Game?;
+    if (game == null || game.phase != GamePhase.idle) return;
+
+    _dragging = true;
+    _dragOriginPosition = position.clone();
+    _accumulatedDelta = Vector2.zero();
+    _dragPreviewNeighbor = null;
+    event.handled = true;
+  }
+
+  @override
+  void onDragUpdate(DragUpdateEvent event) {
+    if (!_dragging) return;
+    _accumulatedDelta += event.localDelta;
+
+    final threshold = size.x * 0.3;
+    final direction = _dominantDirection(_accumulatedDelta, threshold);
+    if (direction == null) return; // below threshold — no preview yet
+
+    // Constrain preview offset to dominant axis only
+    final axisOffset = direction == SwipeDirection.left || direction == SwipeDirection.right
+        ? Vector2(_accumulatedDelta.x.clamp(-size.x * 0.5, size.x * 0.5), 0)
+        : Vector2(0, _accumulatedDelta.y.clamp(-size.y * 0.5, size.y * 0.5));
+
+    position = _dragOriginPosition + axisOffset;
+
+    // Preview neighbor tile (subtle counter-offset)
+    final game = findGame() as Match3Game?;
+    if (game == null) return;
+    final neighborX = gridX + direction.dx;
+    final neighborY = gridY + direction.dy;
+    final neighbor = game.world.tileAt(neighborX, neighborY);
+    if (neighbor != null && neighbor != _dragPreviewNeighbor) {
+      // Restore previous neighbor if direction changed
+      if (_dragPreviewNeighbor != null) {
+        _dragPreviewNeighbor!.position = _dragNeighborOrigin;
+      }
+      _dragPreviewNeighbor = neighbor;
+      _dragNeighborOrigin = neighbor.position.clone();
+    }
+    if (_dragPreviewNeighbor != null) {
+      _dragPreviewNeighbor!.position = _dragNeighborOrigin - axisOffset * 0.3;
+    }
+  }
+
+  @override
+  void onDragEnd(DragEndEvent event) {
+    super.onDragEnd(event);
+    if (!_dragging) return;
+    _dragging = false;
+
+    // Snap tiles back to home positions before handing off to runSwap
+    // (runSwap records position at start, so must be canonical first)
+    position = _dragOriginPosition;
+    if (_dragPreviewNeighbor != null) {
+      _dragPreviewNeighbor!.position = _dragNeighborOrigin;
+      _dragPreviewNeighbor = null;
+    }
+
+    final direction = _dominantDirection(_accumulatedDelta, size.x * 0.3);
+    if (direction == null) return; // too short — ignore
+
+    final game = findGame() as Match3Game?;
+    game?.onTileSwipe(this, direction);
+  }
+
+  @override
+  void onDragCancel(DragCancelEvent event) {
+    super.onDragCancel(event);
+    if (!_dragging) return;
+    _dragging = false;
+    position = _dragOriginPosition;
+    if (_dragPreviewNeighbor != null) {
+      _dragPreviewNeighbor!.position = _dragNeighborOrigin;
+      _dragPreviewNeighbor = null;
+    }
   }
 }

--- a/lib/game/match3_game.dart
+++ b/lib/game/match3_game.dart
@@ -10,6 +10,17 @@ import '../services/progress_service.dart';
 
 enum GamePhase { idle, swapping, matching, falling, cascading }
 
+enum SwipeDirection {
+  up(0, -1),
+  down(0, 1),
+  left(-1, 0),
+  right(1, 0);
+
+  const SwipeDirection(this.dx, this.dy);
+  final int dx;
+  final int dy;
+}
+
 // Legal state transitions
 const _validTransitions = <GamePhase, Set<GamePhase>>{
   GamePhase.idle: {GamePhase.swapping},
@@ -90,5 +101,21 @@ class Match3Game extends FlameGame<GridWorld> with RiverpodGameMixin {
     tileA.deselect();
     _selectedTile = null;
     world.runSwap(tileA, tile);
+  }
+
+  void onTileSwipe(GridTile tile, SwipeDirection direction) {
+    if (phase != GamePhase.idle) return;
+
+    final targetX = tile.gridX + direction.dx;
+    final targetY = tile.gridY + direction.dy;
+
+    // Clear any pending tap selection so the two input paths don't conflict
+    _selectedTile?.deselect();
+    _selectedTile = null;
+
+    final neighbor = world.tileAt(targetX, targetY);
+    if (neighbor == null) return; // out-of-bounds or empty cell
+
+    world.runSwap(tile, neighbor);
   }
 }

--- a/lib/game/theme/tile_palette.dart
+++ b/lib/game/theme/tile_palette.dart
@@ -13,4 +13,4 @@ final Map<TileType, Color> kTileGlowPalette = {
 };
 
 // Selection now uses glow border — transparent fill (border drawn by _GlowBorder).
-const Color kTileSelectedOverlay = Color(0x00000000);
+const Color kTileSelectedOverlay = Colors.transparent;

--- a/lib/game/world/grid_world.dart
+++ b/lib/game/world/grid_world.dart
@@ -424,7 +424,7 @@ class _CosmicBackground extends PositionComponent {
       Rect.fromCenter(center: Offset(size.x / 2, size.y * 0.15),
           width: size.x * 1.2, height: size.y * 0.6),
       Paint()..shader = RadialGradient(
-        colors: [kCosmicNebulaA.withValues(alpha: 0.4), const Color(0x00000000)],
+        colors: [kCosmicNebulaA.withValues(alpha: 0.4), Colors.transparent],
       ).createShader(Rect.fromLTWH(0, 0, size.x, size.y * 0.4)),
     );
 
@@ -433,7 +433,7 @@ class _CosmicBackground extends PositionComponent {
       Rect.fromCenter(center: Offset(size.x * 0.85, size.y * 0.85),
           width: size.x * 0.9, height: size.y * 0.5),
       Paint()..shader = RadialGradient(
-        colors: [kCosmicNebulaB.withValues(alpha: 0.33), const Color(0x00000000)],
+        colors: [kCosmicNebulaB.withValues(alpha: 0.33), Colors.transparent],
       ).createShader(Rect.fromLTWH(size.x * 0.4, size.y * 0.55,
           size.x * 0.6, size.y * 0.45)),
     );

--- a/lib/game/world/grid_world.dart
+++ b/lib/game/world/grid_world.dart
@@ -113,6 +113,13 @@ class GridWorld extends World {
   Vector2 _tilePosition(int x, int y) =>
       _boardOffset + Vector2(x * tileSize, y * tileSize);
 
+  /// Returns the tile component at grid position (x, y), or null if out of
+  /// bounds or the cell is empty (e.g. a tile currently falling).
+  GridTile? tileAt(int x, int y) {
+    if (x < 0 || x >= cols || y < 0 || y >= rows) return null;
+    return tiles[x][y];
+  }
+
   void _updateScoreNotifier() {
     (findGame() as Match3Game?)?.scoreNotifier.value =
         (score: score.value, best: _bestScore);

--- a/lib/widgets/hud_overlay.dart
+++ b/lib/widgets/hud_overlay.dart
@@ -20,7 +20,7 @@ class HudOverlay extends StatelessWidget {
                   child: _StatCard(label: 'SCORE',
                       value: scores.score.toString())),
               const SizedBox(width: 8),
-              Expanded(flex: 1,
+              Expanded(
                   child: _StatCard(label: 'BEST',
                       value: scores.best.toString())),
             ],

--- a/test/game/game_fsm_test.dart
+++ b/test/game/game_fsm_test.dart
@@ -1,6 +1,22 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:cosmic_match/game/match3_game.dart';
 
+/// Lightweight stub mirroring onTileSwipe guard logic without a live Flame engine.
+/// Mirrors the phase check, selection clear, and null-neighbor guard from
+/// Match3Game.onTileSwipe exactly.
+class _SwipeStub {
+  GamePhase phase = GamePhase.idle;
+  bool swapCalled = false;
+  bool selectedCleared = false;
+
+  void onTileSwipe({required bool neighborExists}) {
+    if (phase != GamePhase.idle) return;
+    selectedCleared = true; // mirrors _selectedTile?.deselect() + _selectedTile = null
+    if (!neighborExists) return;
+    swapCalled = true; // mirrors world.runSwap(tile, neighbor)
+  }
+}
+
 /// Lightweight FSM wrapper for testing without spinning up a Flame engine.
 /// Mirrors Match3Game's _validTransitions and transitionTo logic exactly.
 class _TestFsm {
@@ -133,6 +149,37 @@ void main() {
       fsm.transitionTo(GamePhase.falling);
       fsm.transitionTo(GamePhase.idle);
       expect(fsm.phase, GamePhase.idle);
+    });
+  });
+
+  group('onTileSwipe guard logic', () {
+    test('does nothing when phase is not idle', () {
+      final stub = _SwipeStub()..phase = GamePhase.swapping;
+      stub.onTileSwipe(neighborExists: true);
+      expect(stub.swapCalled, isFalse);
+      expect(stub.selectedCleared, isFalse);
+    });
+
+    test('does not swap when neighbor is out of bounds (null)', () {
+      final stub = _SwipeStub();
+      stub.onTileSwipe(neighborExists: false);
+      // Selection IS cleared before the null-neighbor guard fires
+      expect(stub.selectedCleared, isTrue);
+      expect(stub.swapCalled, isFalse);
+    });
+
+    test('calls runSwap when idle and neighbor exists', () {
+      final stub = _SwipeStub();
+      stub.onTileSwipe(neighborExists: true);
+      expect(stub.selectedCleared, isTrue);
+      expect(stub.swapCalled, isTrue);
+    });
+
+    test('does not clear selection when phase is non-idle', () {
+      // Even with a valid neighbor, non-idle phase must return before clearing
+      final stub = _SwipeStub()..phase = GamePhase.falling;
+      stub.onTileSwipe(neighborExists: true);
+      expect(stub.selectedCleared, isFalse);
     });
   });
 }

--- a/test/game/grid_world_swap_test.dart
+++ b/test/game/grid_world_swap_test.dart
@@ -44,4 +44,46 @@ void main() {
       expect(() => world.swapTilesForTest(0, 0, 0, 1), returnsNormally);
     });
   });
+
+  group('GridWorld.tileAt — bounds checking', () {
+    late GridWorld world;
+
+    setUp(() {
+      world = GridWorld();
+      world.grid = List.generate(
+          GridWorld.cols, (_) => List.generate(GridWorld.rows, (_) => null));
+      world.tiles = List.generate(
+          GridWorld.cols, (_) => List.generate(GridWorld.rows, (_) => null));
+    });
+
+    test('returns null for negative x', () {
+      expect(world.tileAt(-1, 0), isNull);
+    });
+
+    test('returns null for x == cols (upper boundary)', () {
+      expect(world.tileAt(GridWorld.cols, 0), isNull);
+    });
+
+    test('returns null for negative y', () {
+      expect(world.tileAt(0, -1), isNull);
+    });
+
+    test('returns null for y == rows (upper boundary)', () {
+      expect(world.tileAt(0, GridWorld.rows), isNull);
+    });
+
+    test('returns null when tile slot is empty (null component)', () {
+      // tiles[0][0] is null by setUp
+      expect(world.tileAt(0, 0), isNull);
+    });
+
+    test('returns null for in-bounds x at right edge (cols-1 is valid)', () {
+      // Ensures the >= guard is correct: cols-1 is inside, cols is outside.
+      expect(world.tileAt(GridWorld.cols - 1, 0), isNull); // null component, not crash
+    });
+
+    test('returns null for in-bounds y at bottom edge (rows-1 is valid)', () {
+      expect(world.tileAt(0, GridWorld.rows - 1), isNull); // null component, not crash
+    });
+  });
 }

--- a/test/game/tile_swipe_test.dart
+++ b/test/game/tile_swipe_test.dart
@@ -1,0 +1,76 @@
+import 'package:flame/components.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cosmic_match/game/components/grid_tile.dart';
+import 'package:cosmic_match/game/match3_game.dart';
+import 'package:cosmic_match/models/tile_type.dart';
+
+GridTile _tile({int x = 0, int y = 0, double tileSize = 60}) {
+  final tile = GridTile(
+    gridX: x,
+    gridY: y,
+    tileType: TileType.blue,
+    position: Vector2.zero(),
+    size: Vector2.all(tileSize),
+  );
+  tile.onLoad();
+  return tile;
+}
+
+void main() {
+  group('SwipeDirection', () {
+    test('up has dy=-1, dx=0', () {
+      expect(SwipeDirection.up.dx, 0);
+      expect(SwipeDirection.up.dy, -1);
+    });
+    test('down has dy=1, dx=0', () {
+      expect(SwipeDirection.down.dx, 0);
+      expect(SwipeDirection.down.dy, 1);
+    });
+    test('left has dx=-1, dy=0', () {
+      expect(SwipeDirection.left.dx, -1);
+      expect(SwipeDirection.left.dy, 0);
+    });
+    test('right has dx=1, dy=0', () {
+      expect(SwipeDirection.right.dx, 1);
+      expect(SwipeDirection.right.dy, 0);
+    });
+  });
+
+  group('GridTile._dominantDirection (via threshold logic)', () {
+    test('horizontal delta dominates when |dx| >= |dy|', () {
+      const dx = 30.0;
+      const dy = 10.0;
+      expect(dx.abs() >= dy.abs(), isTrue); // horizontal dominates
+      expect(dx > 0, isTrue); // → right
+    });
+
+    test('vertical delta dominates when |dy| > |dx|', () {
+      const dx = 5.0;
+      const dy = -25.0;
+      expect(dy.abs() > dx.abs(), isTrue); // vertical dominates
+      expect(dy < 0, isTrue); // → up
+    });
+
+    test('delta below threshold produces no direction', () {
+      const tileSize = 60.0;
+      const threshold = tileSize * 0.3; // 18
+      final delta = Vector2(10, 5); // length ≈ 11.2 < 18
+      expect(delta.length < threshold, isTrue);
+    });
+
+    test('delta above threshold in x-axis produces direction', () {
+      const tileSize = 60.0;
+      const threshold = tileSize * 0.3; // 18
+      final delta = Vector2(25, 5); // length ≈ 25.5 > 18
+      expect(delta.length >= threshold, isTrue);
+      expect(delta.x.abs() >= delta.y.abs(), isTrue); // → left or right
+    });
+  });
+
+  group('GridTile drag state initializes clean', () {
+    test('tile construction succeeds with drag mixin', () {
+      final tile = _tile();
+      expect(tile, isNotNull);
+    });
+  });
+}

--- a/test/game/tile_swipe_test.dart
+++ b/test/game/tile_swipe_test.dart
@@ -4,7 +4,7 @@ import 'package:cosmic_match/game/components/grid_tile.dart';
 import 'package:cosmic_match/game/match3_game.dart';
 import 'package:cosmic_match/models/tile_type.dart';
 
-GridTile _tile({int x = 0, int y = 0, double tileSize = 60}) {
+Future<GridTile> _tile({int x = 0, int y = 0, double tileSize = 60}) async {
   final tile = GridTile(
     gridX: x,
     gridY: y,
@@ -12,7 +12,7 @@ GridTile _tile({int x = 0, int y = 0, double tileSize = 60}) {
     position: Vector2.zero(),
     size: Vector2.all(tileSize),
   );
-  tile.onLoad();
+  await tile.onLoad();
   return tile;
 }
 
@@ -36,40 +36,44 @@ void main() {
     });
   });
 
-  group('GridTile._dominantDirection (via threshold logic)', () {
-    test('horizontal delta dominates when |dx| >= |dy|', () {
-      const dx = 30.0;
-      const dy = 10.0;
-      expect(dx.abs() >= dy.abs(), isTrue); // horizontal dominates
-      expect(dx > 0, isTrue); // → right
+  group('GridTile.dominantDirectionForTest', () {
+    late GridTile tile;
+
+    setUp(() async {
+      tile = await _tile(tileSize: 60); // threshold = size.x * 0.3 = 18
     });
 
-    test('vertical delta dominates when |dy| > |dx|', () {
-      const dx = 5.0;
-      const dy = -25.0;
-      expect(dy.abs() > dx.abs(), isTrue); // vertical dominates
-      expect(dy < 0, isTrue); // → up
+    test('returns null when delta below threshold', () {
+      // length ≈ 11.2 < 18
+      expect(tile.dominantDirectionForTest(Vector2(10, 5), 18), isNull);
     });
 
-    test('delta below threshold produces no direction', () {
-      const tileSize = 60.0;
-      const threshold = tileSize * 0.3; // 18
-      final delta = Vector2(10, 5); // length ≈ 11.2 < 18
-      expect(delta.length < threshold, isTrue);
+    test('returns right when dx positive and |dx| >= |dy|', () {
+      expect(tile.dominantDirectionForTest(Vector2(25, 5), 18), SwipeDirection.right);
     });
 
-    test('delta above threshold in x-axis produces direction', () {
-      const tileSize = 60.0;
-      const threshold = tileSize * 0.3; // 18
-      final delta = Vector2(25, 5); // length ≈ 25.5 > 18
-      expect(delta.length >= threshold, isTrue);
-      expect(delta.x.abs() >= delta.y.abs(), isTrue); // → left or right
+    test('returns left when dx negative and |dx| >= |dy|', () {
+      expect(tile.dominantDirectionForTest(Vector2(-25, 5), 18), SwipeDirection.left);
+    });
+
+    test('returns down when dy positive and |dy| > |dx|', () {
+      expect(tile.dominantDirectionForTest(Vector2(5, 25), 18), SwipeDirection.down);
+    });
+
+    test('returns up when dy negative and |dy| > |dx|', () {
+      expect(tile.dominantDirectionForTest(Vector2(5, -25), 18), SwipeDirection.up);
+    });
+
+    test('horizontal wins tie when |dx| == |dy| (>= branch)', () {
+      // When |dx| == |dy|, the >= condition picks the horizontal axis.
+      final dir = tile.dominantDirectionForTest(Vector2(20, 20), 18);
+      expect(dir, anyOf(SwipeDirection.left, SwipeDirection.right));
     });
   });
 
   group('GridTile drag state initializes clean', () {
-    test('tile construction succeeds with drag mixin', () {
-      final tile = _tile();
+    test('tile construction succeeds with drag mixin', () async {
+      final tile = await _tile();
       expect(tile, isNotNull);
     });
   });


### PR DESCRIPTION
## Summary

- Adds single-swipe gesture to swap tiles: press + drag in a cardinal direction to trigger a swap, replacing the previous two-tap (select → target) flow
- Tap-to-select remains intact as a fallback input path — no existing behaviour removed
- Input-only change: match detection, scoring, cascade, and board state are untouched

## Changes

### `lib/game/world/grid_world.dart`
- Added `tileAt(int x, int y) → GridTile?` — bounds-checked lookup by grid coordinates; returns `null` for out-of-bounds or mid-fall cells

### `lib/game/match3_game.dart`
- Added `SwipeDirection` enum (`up`, `down`, `left`, `right`) with `dx`/`dy` offsets
- Added `onTileSwipe(GridTile tile, SwipeDirection direction)` — clears any pending tap selection, resolves the neighbor via `world.tileAt()`, and calls the existing `world.runSwap()`

### `lib/game/components/grid_tile.dart`
- Added `DragCallbacks` mixin alongside existing `TapCallbacks`
- Implemented `onDragStart` / `onDragUpdate` / `onDragEnd` / `onDragCancel`
- During drag: accumulates delta, applies constrained preview offset to both dragged tile and neighbor (30% threshold, axis-locked)
- On drag end: resets tile positions to canonical grid positions before calling `onTileSwipe`, preventing animation start-position artifacts
- Input gate mirrors existing tap guard: drops events when `game.phase != GamePhase.idle`

### `test/game/tile_swipe_test.dart` (new)
- Unit tests for `SwipeDirection` offsets, threshold math, and delta dominance logic — no Flame engine required

## Validation

| Check | Result |
|-------|--------|
| `flutter analyze` | ✅ No issues found |
| `flutter test` | ✅ 146 passed, 0 failed |

## Edge cases covered

- Drag below threshold (< 30% tile width) → no swap, snap back
- Diagonal drag → dominant axis selected, single cardinal direction committed
- Drag toward board edge → `tileAt()` returns `null` → early exit, snap back
- Drag during non-idle phase → `onDragStart` returns immediately (input gate)
- Mid-fall tile cell → `tileAt()` returns `null` → no swap
- Pending tap selection cleared on swipe to avoid orphaned highlight
- `onDragCancel` (pointer leaves window) restores both tiles correctly

Fixes #81