### PR TITLE
feat: add in-app feedback with annotated screenshot → GitHub issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,12 +124,14 @@ jobs:
       - name: Build release AAB
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-        run: flutter build appbundle --release --dart-define=SENTRY_DSN=$SENTRY_DSN
+          GITHUB_FEEDBACK_TOKEN: ${{ secrets.GITHUB_FEEDBACK_TOKEN }}
+        run: flutter build appbundle --release --dart-define=SENTRY_DSN=$SENTRY_DSN --dart-define=GITHUB_FEEDBACK_TOKEN=$GITHUB_FEEDBACK_TOKEN
 
       - name: Build release APK
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-        run: flutter build apk --release --dart-define=SENTRY_DSN=$SENTRY_DSN
+          GITHUB_FEEDBACK_TOKEN: ${{ secrets.GITHUB_FEEDBACK_TOKEN }}
+        run: flutter build apk --release --dart-define=SENTRY_DSN=$SENTRY_DSN --dart-define=GITHUB_FEEDBACK_TOKEN=$GITHUB_FEEDBACK_TOKEN
 
       - name: Upload signed AAB
         if: steps.keystore.outputs.used_real == 'yes'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,8 @@ flutter build apk --debug
 # Build (release AAB) — requires android/key.properties (see android/key.properties.example)
 flutter build appbundle --release
 # To enable Sentry crash reporting, add: --dart-define=SENTRY_DSN=<your-dsn>
-# (CI injects this automatically via the SENTRY_DSN secret)
+# To enable in-app feedback, add: --dart-define=GITHUB_FEEDBACK_TOKEN=<your-pat>
+# (CI injects both automatically via repository secrets)
 
 # Generate Hive adapters (run after adding new Hive types)
 dart run build_runner build --delete-conflicting-outputs
@@ -34,11 +35,14 @@ lib/
                   #   kTileGlowPalette — derived from TileType.glowValue, used for selection border;
                   #   kTileSelectedOverlay — transparent, selection drawn by _GlowBorder stroke;
                   #   cosmic_theme.dart — Lyra galaxy tokens: kCosmicInk, kCosmicNebulaA/B, kCosmicAccent, kBoardBackdrop, kGridLine)
-  models/         # Pure data: Score, TileType, LevelProgress
+  models/         # Pure data: Score, TileType, LevelProgress, FeedbackItem
   screens/        # Flutter screens: HomeScreen, MapScreen, GameScreen, modals
                   # Navigation: _Screen enum + _buildScreen() in main.dart
-  services/       # Hive persistence (ProgressService) and key management (KeyService)
-  widgets/        # Flutter overlay widgets (HudOverlay — driven by Match3Game.scoreNotifier)
+  services/       # Hive persistence (ProgressService) and key management (KeyService);
+                  #   FeedbackQueueService (offline feedback queue, Hive-backed, CRC32);
+                  #   GitHubFeedbackClient (screenshot upload + issue creation via GitHub API)
+  widgets/        # Flutter overlay widgets (HudOverlay — driven by Match3Game.scoreNotifier);
+                  #   FeedbackModal (bottom-sheet annotation canvas + text field)
 test/             # Unit tests mirror lib/ structure
 ```
 
@@ -70,20 +74,23 @@ Detection passes run in strict priority order. **Do NOT reorder**:
 Tiles consumed by a higher-priority pass are added to the `claimed` set and skipped by
 lower-priority passes, preventing double-counting.
 
-### CRC32 Persistence Contract (`lib/models/level_progress.dart`, `lib/services/progress_service.dart`)
+### CRC32 Persistence Contract (`lib/models/level_progress.dart`, `lib/services/progress_service.dart`; `lib/models/feedback_item.dart`, `lib/services/feedback_queue_service.dart`)
 
-`LevelProgress.toMap()` must always include a `crc` field computed over all other fields
-using `_canonicalize()` (key-sorted representation). `ProgressService._isValid()` rejects
-any map missing or mismatching the CRC and resets to `LevelProgress.initial()`.
+Any Hive-backed model must include a `crc` field in its `toMap()` output, computed over
+all other fields using a key-sorted canonical representation. The corresponding service's
+`_isValid()` must reject any map with a missing or mismatched CRC.
 
-When adding new fields to `LevelProgress`:
+- `LevelProgress.toMap()` / `ProgressService._isValid()` — resets to `LevelProgress.initial()` on tamper
+- `FeedbackItem.toMap()` / `FeedbackQueueService._isValid()` — skips the invalid queue entry on tamper
+
+When adding new fields to either model:
 - Include them in `toMap()` before computing the CRC
 - The canonicalized format sorts keys alphabetically, so insertion order does not matter
 
-**Cipher invariant**: `ProgressService` accepts an optional `HiveAesCipher` (SEC-004).
-A box opened with a cipher cannot later be opened without one (and vice-versa). For V1
-there are no existing users, so this is safe. In future migrations, ensure the cipher
-parameter is consistent across all `ProgressService` instantiation sites.
+**Cipher invariant**: `ProgressService` and `FeedbackQueueService` both accept an optional
+`HiveAesCipher` (SEC-004). A box opened with a cipher cannot later be opened without one
+(and vice-versa). For V1 there are no existing users, so this is safe. In future migrations,
+ensure the cipher parameter is consistent across all instantiation sites.
 
 ### SEC-008 Integrity Controls
 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -50,6 +50,11 @@ subprojects {
                 sourceCompatibility = JavaVersion.VERSION_17
                 targetCompatibility = JavaVersion.VERSION_17
             }
+            tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+                compilerOptions {
+                    jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+                }
+            }
         }
     }
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,12 +18,19 @@ import 'services/key_service.dart';
 import 'services/progress_service.dart';
 import 'widgets/feedback_modal.dart';
 
+/// WorkManager background-task entry point.
+///
+/// Runs in a **separate Dart isolate** spun up by the OS scheduler, so all
+/// Flutter/Hive state must be re-initialised here. [KeyService.getCipher] is
+/// called to match the cipher used in the foreground app — the box must be
+/// opened with the same cipher or Hive will reject it.
 @pragma('vm:entry-point')
 void callbackDispatcher() {
   wm.Workmanager().executeTask((task, inputData) async {
     if (task == 'feedbackRetry') {
       await Hive.initFlutter();
-      final queue = FeedbackQueueService(cipher: null);
+      final cipher = await KeyService().getCipher();
+      final queue = FeedbackQueueService(cipher: cipher);
       final client = GitHubFeedbackClient();
       final items = await queue.loadQueue();
       for (final item in items) {
@@ -34,8 +41,8 @@ void callbackDispatcher() {
           final issueUrl =
               await client.createIssue(item.description, imageUrl);
           await queue.markUploaded(item.id, issueUrl);
-        } catch (e) {
-          gameLogger.w('feedbackRetry: failed for ${item.id}', error: e);
+        } catch (e, stack) {
+          gameLogger.w('feedbackRetry: failed for ${item.id}', error: e, stackTrace: stack);
         }
       }
     }
@@ -57,8 +64,9 @@ Future<void> main() async {
   final feedbackQueue = FeedbackQueueService(cipher: cipher);
   final feedbackClient = GitHubFeedbackClient();
 
-  // ignore: deprecated_member_use
-  await wm.Workmanager().initialize(callbackDispatcher, isInDebugMode: !kReleaseMode);
+  // isInDebugMode deprecated in workmanager 0.9.x but not yet removed.
+  // Remove this argument once workmanager drops the parameter.
+  await wm.Workmanager().initialize(callbackDispatcher, isInDebugMode: !kReleaseMode); // ignore: deprecated_member_use
 
   gameLogger.i('CosmicMatch initialised — hive ready, progressService ready');
 
@@ -132,20 +140,32 @@ class _CosmicMatchAppState extends State<CosmicMatchApp> {
   Future<void> _scheduleRetryIfNeeded() async {
     final items = await widget.feedbackQueue.loadQueue();
     if (items.any((i) => !i.uploaded)) {
-      await wm.Workmanager().registerOneOffTask(
-        'feedbackRetry',
-        'feedbackRetry',
-        constraints: wm.Constraints(networkType: wm.NetworkType.connected),
-      );
+      try {
+        await wm.Workmanager().registerOneOffTask(
+          'feedbackRetry',
+          'feedbackRetry',
+          constraints: wm.Constraints(networkType: wm.NetworkType.connected),
+        );
+      } catch (e, stack) {
+        gameLogger.w('_scheduleRetryIfNeeded: WorkManager registration failed', error: e, stackTrace: stack);
+      }
     }
   }
 
   Future<Uint8List> _captureScreenshot() async {
-    final boundary = _repaintBoundaryKey.currentContext!.findRenderObject()
-        as RenderRepaintBoundary;
+    final context = _repaintBoundaryKey.currentContext;
+    if (context == null) {
+      gameLogger.w('_captureScreenshot: repaint boundary context is null');
+      throw StateError('RepaintBoundary not yet mounted');
+    }
+    final boundary = context.findRenderObject() as RenderRepaintBoundary;
     final image = await boundary.toImage(pixelRatio: 2.0);
     final data = await image.toByteData(format: ImageByteFormat.png);
-    return data!.buffer.asUint8List();
+    if (data == null) {
+      gameLogger.w('_captureScreenshot: toByteData returned null');
+      throw StateError('Failed to encode screenshot to PNG');
+    }
+    return data.buffer.asUint8List();
   }
 
   Future<void> _showFeedback() async {
@@ -161,6 +181,7 @@ class _CosmicMatchAppState extends State<CosmicMatchApp> {
         ),
       );
     } catch (e) {
+      gameLogger.w('_showFeedback: screenshot capture failed', error: e);
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Could not capture screenshot')),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,15 +1,47 @@
-import 'package:flame_riverpod/flame_riverpod.dart';
+import 'dart:convert';
+import 'dart:ui';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:workmanager/workmanager.dart' as wm;
 import 'core/logger.dart';
 import 'game/match3_game.dart';
+import 'screens/game_screen.dart';
+import 'screens/home_screen.dart';
+import 'services/feedback_queue_service.dart';
+import 'services/github_feedback_client.dart';
 import 'services/key_service.dart';
 import 'services/progress_service.dart';
-import 'widgets/hud_overlay.dart';
+import 'widgets/feedback_modal.dart';
+
+@pragma('vm:entry-point')
+void callbackDispatcher() {
+  wm.Workmanager().executeTask((task, inputData) async {
+    if (task == 'feedbackRetry') {
+      await Hive.initFlutter();
+      final queue = FeedbackQueueService(cipher: null);
+      final client = GitHubFeedbackClient();
+      final items = await queue.loadQueue();
+      for (final item in items) {
+        if (item.uploaded) continue;
+        try {
+          final pngBytes = base64Decode(item.screenshotBase64);
+          final imageUrl = await client.uploadImage(item.id, pngBytes);
+          final issueUrl =
+              await client.createIssue(item.description, imageUrl);
+          await queue.markUploaded(item.id, issueUrl);
+        } catch (e) {
+          gameLogger.w('feedbackRetry: failed for ${item.id}', error: e);
+        }
+      }
+    }
+    return true;
+  });
+}
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -22,10 +54,20 @@ Future<void> main() async {
   await Hive.initFlutter();
   final cipher = await KeyService().getCipher();
   final progressService = ProgressService(cipher: cipher);
+  final feedbackQueue = FeedbackQueueService(cipher: cipher);
+  final feedbackClient = GitHubFeedbackClient();
+
+  // ignore: deprecated_member_use
+  await wm.Workmanager().initialize(callbackDispatcher, isInDebugMode: !kReleaseMode);
 
   gameLogger.i('CosmicMatch initialised — hive ready, progressService ready');
 
-  void launch() => runApp(ProviderScope(child: CosmicMatchApp(progressService: progressService)));
+  void launch() => runApp(ProviderScope(
+      child: CosmicMatchApp(
+        progressService: progressService,
+        feedbackQueue: feedbackQueue,
+        feedbackClient: feedbackClient,
+      )));
 
   const sentryDsn = String.fromEnvironment('SENTRY_DSN', defaultValue: '');
   if (sentryDsn.isEmpty) {
@@ -57,23 +99,90 @@ Future<void> main() async {
   }
 }
 
+enum _Screen { home, game }
+
 class CosmicMatchApp extends StatefulWidget {
   final ProgressService progressService;
+  final FeedbackQueueService feedbackQueue;
+  final GitHubFeedbackClient feedbackClient;
 
-  const CosmicMatchApp({super.key, required this.progressService});
+  const CosmicMatchApp({
+    super.key,
+    required this.progressService,
+    required this.feedbackQueue,
+    required this.feedbackClient,
+  });
 
   @override
   State<CosmicMatchApp> createState() => _CosmicMatchAppState();
 }
 
 class _CosmicMatchAppState extends State<CosmicMatchApp> {
-  final _gameKey = GlobalKey<RiverpodAwareGameWidgetState<Match3Game>>();
+  _Screen _currentScreen = _Screen.home;
   late final Match3Game _game;
+  final _repaintBoundaryKey = GlobalKey();
 
   @override
   void initState() {
     super.initState();
     _game = Match3Game(progressService: widget.progressService);
+    _scheduleRetryIfNeeded();
+  }
+
+  Future<void> _scheduleRetryIfNeeded() async {
+    final items = await widget.feedbackQueue.loadQueue();
+    if (items.any((i) => !i.uploaded)) {
+      await wm.Workmanager().registerOneOffTask(
+        'feedbackRetry',
+        'feedbackRetry',
+        constraints: wm.Constraints(networkType: wm.NetworkType.connected),
+      );
+    }
+  }
+
+  Future<Uint8List> _captureScreenshot() async {
+    final boundary = _repaintBoundaryKey.currentContext!.findRenderObject()
+        as RenderRepaintBoundary;
+    final image = await boundary.toImage(pixelRatio: 2.0);
+    final data = await image.toByteData(format: ImageByteFormat.png);
+    return data!.buffer.asUint8List();
+  }
+
+  Future<void> _showFeedback() async {
+    try {
+      final screenshot = await _captureScreenshot();
+      if (!mounted) return;
+      showDialog(
+        context: context,
+        builder: (_) => FeedbackModal(
+          screenshot: screenshot,
+          queue: widget.feedbackQueue,
+          client: widget.feedbackClient,
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Could not capture screenshot')),
+      );
+    }
+  }
+
+  Widget _buildScreen() {
+    switch (_currentScreen) {
+      case _Screen.home:
+        return HomeScreen(
+          onPlay: () => setState(() => _currentScreen = _Screen.game),
+          onMap: () {}, // Map not yet implemented
+          onFeedback: _showFeedback,
+        );
+      case _Screen.game:
+        return GameScreen(
+          game: _game,
+          onBack: () => setState(() => _currentScreen = _Screen.home),
+          onFeedback: _showFeedback,
+        );
+    }
   }
 
   @override
@@ -84,12 +193,9 @@ class _CosmicMatchAppState extends State<CosmicMatchApp> {
         scaffoldBackgroundColor: const Color(0xFF0D0A1A),
       ),
       home: SafeArea(
-        child: RiverpodAwareGameWidget(
-          key: _gameKey,
-          game: _game,
-          overlayBuilderMap: {
-            'hud': (context, game) => HudOverlay(game: game as Match3Game),
-          },
+        child: RepaintBoundary(
+          key: _repaintBoundaryKey,
+          child: _buildScreen(),
         ),
       ),
     );

--- a/lib/models/feedback_item.dart
+++ b/lib/models/feedback_item.dart
@@ -1,0 +1,63 @@
+import 'package:archive/archive.dart';
+
+class FeedbackItem {
+  final String id;
+  final DateTime timestamp;
+  final String description;
+  final String screenshotBase64;
+  final bool uploaded;
+  final String? githubIssueUrl;
+
+  const FeedbackItem({
+    required this.id,
+    required this.timestamp,
+    required this.description,
+    required this.screenshotBase64,
+    this.uploaded = false,
+    this.githubIssueUrl,
+  });
+
+  FeedbackItem copyWith({
+    bool? uploaded,
+    String? githubIssueUrl,
+  }) {
+    return FeedbackItem(
+      id: id,
+      timestamp: timestamp,
+      description: description,
+      screenshotBase64: screenshotBase64,
+      uploaded: uploaded ?? this.uploaded,
+      githubIssueUrl: githubIssueUrl ?? this.githubIssueUrl,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    final data = <String, dynamic>{
+      'id': id,
+      'timestamp': timestamp.millisecondsSinceEpoch,
+      'description': description,
+      'screenshotBase64': screenshotBase64,
+      'uploaded': uploaded,
+      'githubIssueUrl': githubIssueUrl,
+    };
+    data['crc'] = getCrc32(canonicalize(data).codeUnits);
+    return data;
+  }
+
+  factory FeedbackItem.fromMap(Map raw) {
+    return FeedbackItem(
+      id: raw['id'] as String,
+      timestamp:
+          DateTime.fromMillisecondsSinceEpoch(raw['timestamp'] as int),
+      description: raw['description'] as String,
+      screenshotBase64: raw['screenshotBase64'] as String,
+      uploaded: raw['uploaded'] as bool? ?? false,
+      githubIssueUrl: raw['githubIssueUrl'] as String?,
+    );
+  }
+
+  static String canonicalize(Map<String, dynamic> data) {
+    final keys = data.keys.toList()..sort();
+    return keys.map((k) => '$k:${data[k]}').join(',');
+  }
+}

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -1,5 +1,8 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
 import 'package:flame_riverpod/flame_riverpod.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:google_fonts/google_fonts.dart';
 import '../game/match3_game.dart';
 import '../game/theme/app_theme.dart';
@@ -17,8 +20,9 @@ String formatGameScore(int n) {
 class GameScreen extends StatefulWidget {
   final Match3Game game;
   final VoidCallback onBack;
+  final VoidCallback onFeedback;
 
-  const GameScreen({super.key, required this.game, required this.onBack});
+  const GameScreen({super.key, required this.game, required this.onBack, required this.onFeedback});
 
   @override
   State<GameScreen> createState() => _GameScreenState();
@@ -26,6 +30,15 @@ class GameScreen extends StatefulWidget {
 
 class _GameScreenState extends State<GameScreen> {
   final _gameKey = GlobalKey<RiverpodAwareGameWidgetState<Match3Game>>();
+  final _repaintKey = GlobalKey();
+
+  Future<Uint8List> captureScreenshot() async {
+    final boundary = _repaintKey.currentContext!.findRenderObject()
+        as RenderRepaintBoundary;
+    final image = await boundary.toImage(pixelRatio: 2.0);
+    final data = await image.toByteData(format: ui.ImageByteFormat.png);
+    return data!.buffer.asUint8List();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -36,9 +49,12 @@ class _GameScreenState extends State<GameScreen> {
           children: [
             _buildHUD(),
             Expanded(
-              child: RiverpodAwareGameWidget(
-                key: _gameKey,
-                game: widget.game,
+              child: RepaintBoundary(
+                key: _repaintKey,
+                child: RiverpodAwareGameWidget(
+                  key: _gameKey,
+                  game: widget.game,
+                ),
               ),
             ),
             _buildLegend(),
@@ -69,10 +85,17 @@ class _GameScreenState extends State<GameScreen> {
                   color: Colors.white.withValues(alpha: 0.55),
                 ),
               ),
-              _circleButton(
-                onTap: () {},
-                child: const Icon(Icons.pause, size: 14, color: Colors.white),
-              ),
+              Row(children: [
+                _circleButton(
+                  onTap: () {},
+                  child: const Icon(Icons.pause, size: 14, color: Colors.white),
+                ),
+                const SizedBox(width: 6),
+                _circleButton(
+                  onTap: widget.onFeedback,
+                  child: const Icon(Icons.mail_outline, size: 14, color: Colors.white),
+                ),
+              ]),
             ],
           ),
           const SizedBox(height: 10),

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -1,8 +1,5 @@
-import 'dart:typed_data';
-import 'dart:ui' as ui;
 import 'package:flame_riverpod/flame_riverpod.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:google_fonts/google_fonts.dart';
 import '../game/match3_game.dart';
 import '../game/theme/app_theme.dart';
@@ -30,15 +27,6 @@ class GameScreen extends StatefulWidget {
 
 class _GameScreenState extends State<GameScreen> {
   final _gameKey = GlobalKey<RiverpodAwareGameWidgetState<Match3Game>>();
-  final _repaintKey = GlobalKey();
-
-  Future<Uint8List> captureScreenshot() async {
-    final boundary = _repaintKey.currentContext!.findRenderObject()
-        as RenderRepaintBoundary;
-    final image = await boundary.toImage(pixelRatio: 2.0);
-    final data = await image.toByteData(format: ui.ImageByteFormat.png);
-    return data!.buffer.asUint8List();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -49,12 +37,9 @@ class _GameScreenState extends State<GameScreen> {
           children: [
             _buildHUD(),
             Expanded(
-              child: RepaintBoundary(
-                key: _repaintKey,
-                child: RiverpodAwareGameWidget(
-                  key: _gameKey,
-                  game: widget.game,
-                ),
+              child: RiverpodAwareGameWidget(
+                key: _gameKey,
+                game: widget.game,
               ),
             ),
             _buildLegend(),

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -5,8 +5,9 @@ import '../game/theme/app_theme.dart';
 class HomeScreen extends StatelessWidget {
   final VoidCallback onPlay;
   final VoidCallback onMap;
+  final VoidCallback onFeedback;
 
-  const HomeScreen({super.key, required this.onPlay, required this.onMap});
+  const HomeScreen({super.key, required this.onPlay, required this.onMap, required this.onFeedback});
 
   @override
   Widget build(BuildContext context) {
@@ -179,6 +180,15 @@ class HomeScreen extends StatelessWidget {
                       ),
                       child: const Text('Galaxy Map'),
                     ),
+                  ),
+                  const SizedBox(height: 8),
+                  TextButton(
+                    onPressed: onFeedback,
+                    style: TextButton.styleFrom(
+                      foregroundColor: Colors.white.withValues(alpha: 0.45),
+                      textStyle: const TextStyle(fontSize: 12, letterSpacing: 0.3),
+                    ),
+                    child: const Text('Send feedback'),
                   ),
                 ],
               ),

--- a/lib/services/feedback_queue_service.dart
+++ b/lib/services/feedback_queue_service.dart
@@ -1,0 +1,82 @@
+import 'package:archive/archive.dart';
+import 'package:hive/hive.dart';
+import '../core/logger.dart';
+import '../models/feedback_item.dart';
+
+class FeedbackQueueService {
+  static const _boxName = 'feedback_queue';
+
+  final HiveAesCipher? _cipher;
+
+  FeedbackQueueService({HiveAesCipher? cipher}) : _cipher = cipher;
+
+  Future<List<FeedbackItem>> loadQueue() async {
+    gameLogger.d('FeedbackQueueService.loadQueue');
+    try {
+      final box = await Hive.openBox(_boxName, encryptionCipher: _cipher);
+      final items = <FeedbackItem>[];
+      for (final key in box.keys) {
+        final raw = box.get(key);
+        if (raw == null || raw is! Map || !_isValid(raw)) {
+          gameLogger.w('FeedbackQueueService.loadQueue: skipping invalid item key=$key');
+          continue;
+        }
+        items.add(FeedbackItem.fromMap(raw));
+      }
+      return items;
+    } on HiveError catch (e, stack) {
+      gameLogger.e('FeedbackQueueService.loadQueue: HiveError', error: e, stackTrace: stack);
+      return [];
+    } catch (e, stack) {
+      gameLogger.w('FeedbackQueueService.loadQueue failed', error: e, stackTrace: stack);
+      return [];
+    }
+  }
+
+  Future<void> enqueue(FeedbackItem item) async {
+    gameLogger.d('FeedbackQueueService.enqueue: id=${item.id}');
+    try {
+      final box = await Hive.openBox(_boxName, encryptionCipher: _cipher);
+      await box.put(item.id, item.toMap());
+    } on HiveError catch (e, stack) {
+      gameLogger.e('FeedbackQueueService.enqueue(${item.id}): HiveError', error: e, stackTrace: stack);
+    } catch (e, stack) {
+      gameLogger.w('FeedbackQueueService.enqueue(${item.id}) failed', error: e, stackTrace: stack);
+    }
+  }
+
+  Future<void> markUploaded(String id, String issueUrl) async {
+    gameLogger.d('FeedbackQueueService.markUploaded: id=$id');
+    try {
+      final box = await Hive.openBox(_boxName, encryptionCipher: _cipher);
+      final raw = box.get(id);
+      if (raw == null || raw is! Map || !_isValid(raw)) return;
+      final item = FeedbackItem.fromMap(raw);
+      final updated = item.copyWith(uploaded: true, githubIssueUrl: issueUrl);
+      await box.put(id, updated.toMap());
+    } on HiveError catch (e, stack) {
+      gameLogger.e('FeedbackQueueService.markUploaded($id): HiveError', error: e, stackTrace: stack);
+    } catch (e, stack) {
+      gameLogger.w('FeedbackQueueService.markUploaded($id) failed', error: e, stackTrace: stack);
+    }
+  }
+
+  Future<void> remove(String id) async {
+    gameLogger.d('FeedbackQueueService.remove: id=$id');
+    try {
+      final box = await Hive.openBox(_boxName, encryptionCipher: _cipher);
+      await box.delete(id);
+    } on HiveError catch (e, stack) {
+      gameLogger.e('FeedbackQueueService.remove($id): HiveError', error: e, stackTrace: stack);
+    } catch (e, stack) {
+      gameLogger.w('FeedbackQueueService.remove($id) failed', error: e, stackTrace: stack);
+    }
+  }
+
+  bool _isValid(Map raw) {
+    final storedCrc = raw['crc'] as int?;
+    if (storedCrc == null) return false;
+    final data = Map<String, dynamic>.from(raw)..remove('crc');
+    return getCrc32(FeedbackItem.canonicalize(data).codeUnits) == storedCrc;
+  }
+}

--- a/lib/services/github_feedback_client.dart
+++ b/lib/services/github_feedback_client.dart
@@ -1,0 +1,87 @@
+import 'dart:convert';
+import 'dart:typed_data';
+import 'package:http/http.dart' as http;
+import '../core/logger.dart';
+
+const String _kToken =
+    String.fromEnvironment('GITHUB_FEEDBACK_TOKEN', defaultValue: '');
+
+class FeedbackClientException implements Exception {
+  final String message;
+  const FeedbackClientException(this.message);
+  @override
+  String toString() => 'FeedbackClientException: $message';
+}
+
+class GitHubFeedbackClient {
+  static const _repo = 'alexsiri7/cosmic-match';
+
+  Map<String, String> get _headers => {
+        'Authorization': 'token $_kToken',
+        'Content-Type': 'application/json',
+        'Accept': 'application/vnd.github+json',
+      };
+
+  bool get isAvailable => _kToken.isNotEmpty;
+
+  Future<String> uploadImage(String id, Uint8List pngBytes) async {
+    if (_kToken.isEmpty) {
+      throw const FeedbackClientException(
+          'Feedback token not configured — cannot upload image');
+    }
+    gameLogger.d('GitHubFeedbackClient.uploadImage: id=$id');
+
+    final b64 = base64Encode(pngBytes);
+    final uri = Uri.parse(
+        'https://api.github.com/repos/$_repo/contents/docs/feedback/$id.png');
+    final response = await http.put(
+      uri,
+      headers: _headers,
+      body: jsonEncode({
+        'message': 'feedback image $id',
+        'content': b64,
+        'branch': 'main',
+      }),
+    );
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      gameLogger.e(
+          'GitHubFeedbackClient.uploadImage failed: ${response.statusCode}');
+      throw FeedbackClientException(
+          'Image upload failed with status ${response.statusCode}');
+    }
+
+    final json = jsonDecode(response.body) as Map<String, dynamic>;
+    final content = json['content'] as Map<String, dynamic>;
+    return content['download_url'] as String;
+  }
+
+  Future<String> createIssue(String description, String imageUrl) async {
+    if (_kToken.isEmpty) {
+      throw const FeedbackClientException(
+          'Feedback token not configured — cannot create issue');
+    }
+    gameLogger.d('GitHubFeedbackClient.createIssue');
+
+    final uri = Uri.parse('https://api.github.com/repos/$_repo/issues');
+    final response = await http.post(
+      uri,
+      headers: _headers,
+      body: jsonEncode({
+        'title': 'In-app feedback',
+        'body': '$description\n\n![]($imageUrl)',
+        'labels': ['feedback'],
+      }),
+    );
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      gameLogger.e(
+          'GitHubFeedbackClient.createIssue failed: ${response.statusCode}');
+      throw FeedbackClientException(
+          'Issue creation failed with status ${response.statusCode}');
+    }
+
+    final json = jsonDecode(response.body) as Map<String, dynamic>;
+    return json['html_url'] as String;
+  }
+}

--- a/lib/services/github_feedback_client.dart
+++ b/lib/services/github_feedback_client.dart
@@ -1,5 +1,5 @@
 import 'dart:convert';
-import 'dart:typed_data';
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import '../core/logger.dart';
 
@@ -14,18 +14,29 @@ class FeedbackClientException implements Exception {
 }
 
 class GitHubFeedbackClient {
+  GitHubFeedbackClient({http.Client? httpClient})
+      : _token = _kToken,
+        _client = httpClient ?? http.Client();
+
+  @visibleForTesting
+  GitHubFeedbackClient.withToken(String token, {http.Client? httpClient})
+      : _token = token,
+        _client = httpClient ?? http.Client();
+
+  final String _token;
+  final http.Client _client;
   static const _repo = 'alexsiri7/cosmic-match';
 
   Map<String, String> get _headers => {
-        'Authorization': 'token $_kToken',
+        'Authorization': 'token $_token',
         'Content-Type': 'application/json',
         'Accept': 'application/vnd.github+json',
       };
 
-  bool get isAvailable => _kToken.isNotEmpty;
+  bool get isAvailable => _token.isNotEmpty;
 
   Future<String> uploadImage(String id, Uint8List pngBytes) async {
-    if (_kToken.isEmpty) {
+    if (_token.isEmpty) {
       throw const FeedbackClientException(
           'Feedback token not configured — cannot upload image');
     }
@@ -34,7 +45,7 @@ class GitHubFeedbackClient {
     final b64 = base64Encode(pngBytes);
     final uri = Uri.parse(
         'https://api.github.com/repos/$_repo/contents/docs/feedback/$id.png');
-    final response = await http.put(
+    final response = await _client.put(
       uri,
       headers: _headers,
       body: jsonEncode({
@@ -45,8 +56,9 @@ class GitHubFeedbackClient {
     );
 
     if (response.statusCode < 200 || response.statusCode >= 300) {
+      final snippet = response.body.substring(0, response.body.length.clamp(0, 200));
       gameLogger.e(
-          'GitHubFeedbackClient.uploadImage failed: ${response.statusCode}');
+          'GitHubFeedbackClient.uploadImage failed: ${response.statusCode} — $snippet');
       throw FeedbackClientException(
           'Image upload failed with status ${response.statusCode}');
     }
@@ -57,14 +69,14 @@ class GitHubFeedbackClient {
   }
 
   Future<String> createIssue(String description, String imageUrl) async {
-    if (_kToken.isEmpty) {
+    if (_token.isEmpty) {
       throw const FeedbackClientException(
           'Feedback token not configured — cannot create issue');
     }
     gameLogger.d('GitHubFeedbackClient.createIssue');
 
     final uri = Uri.parse('https://api.github.com/repos/$_repo/issues');
-    final response = await http.post(
+    final response = await _client.post(
       uri,
       headers: _headers,
       body: jsonEncode({
@@ -75,8 +87,9 @@ class GitHubFeedbackClient {
     );
 
     if (response.statusCode < 200 || response.statusCode >= 300) {
+      final snippet = response.body.substring(0, response.body.length.clamp(0, 200));
       gameLogger.e(
-          'GitHubFeedbackClient.createIssue failed: ${response.statusCode}');
+          'GitHubFeedbackClient.createIssue failed: ${response.statusCode} — $snippet');
       throw FeedbackClientException(
           'Issue creation failed with status ${response.statusCode}');
     }

--- a/lib/widgets/feedback_modal.dart
+++ b/lib/widgets/feedback_modal.dart
@@ -1,0 +1,334 @@
+import 'dart:convert';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+import 'package:flutter/material.dart';
+import '../game/theme/app_theme.dart';
+import '../models/feedback_item.dart';
+import '../screens/modals.dart';
+import '../services/feedback_queue_service.dart';
+import '../services/github_feedback_client.dart';
+
+class FeedbackModal extends StatefulWidget {
+  final Uint8List screenshot;
+  final FeedbackQueueService queue;
+  final GitHubFeedbackClient client;
+
+  const FeedbackModal({
+    super.key,
+    required this.screenshot,
+    required this.queue,
+    required this.client,
+  });
+
+  @override
+  State<FeedbackModal> createState() => _FeedbackModalState();
+}
+
+class _FeedbackModalState extends State<FeedbackModal> {
+  final _descriptionController = TextEditingController();
+  final List<Offset?> _points = [];
+  bool _isSubmitting = false;
+  bool _drawMode = false;
+
+  @override
+  void dispose() {
+    _descriptionController.dispose();
+    super.dispose();
+  }
+
+  Future<Uint8List> _renderAnnotatedScreenshot() async {
+    final codec = await ui.instantiateImageCodec(widget.screenshot);
+    final frame = await codec.getNextFrame();
+    final image = frame.image;
+
+    final recorder = ui.PictureRecorder();
+    final canvas = Canvas(recorder);
+    canvas.drawImage(image, Offset.zero, Paint());
+
+    if (_points.isNotEmpty) {
+      final paint = Paint()
+        ..color = kLyraAccent
+        ..strokeWidth = 3.0
+        ..strokeCap = StrokeCap.round
+        ..style = PaintingStyle.stroke;
+
+      for (int i = 0; i < _points.length - 1; i++) {
+        if (_points[i] != null && _points[i + 1] != null) {
+          // Scale points from widget coordinates to image coordinates
+          final scaleX = image.width / _imageDisplaySize.width;
+          final scaleY = image.height / _imageDisplaySize.height;
+          canvas.drawLine(
+            Offset(_points[i]!.dx * scaleX, _points[i]!.dy * scaleY),
+            Offset(_points[i + 1]!.dx * scaleX, _points[i + 1]!.dy * scaleY),
+            paint,
+          );
+        }
+      }
+    }
+
+    final picture = recorder.endRecording();
+    final rendered =
+        await picture.toImage(image.width, image.height);
+    final byteData =
+        await rendered.toByteData(format: ui.ImageByteFormat.png);
+    image.dispose();
+    rendered.dispose();
+    return byteData!.buffer.asUint8List();
+  }
+
+  Size _imageDisplaySize = Size.zero;
+
+  Future<void> _submit() async {
+    if (_isSubmitting) return;
+    setState(() => _isSubmitting = true);
+
+    try {
+      final annotatedPng = await _renderAnnotatedScreenshot();
+      final item = FeedbackItem(
+        id: DateTime.now().microsecondsSinceEpoch.toString(),
+        timestamp: DateTime.now(),
+        description: _descriptionController.text,
+        screenshotBase64: base64Encode(annotatedPng),
+      );
+
+      await widget.queue.enqueue(item);
+
+      if (!widget.client.isAvailable) {
+        if (mounted) {
+          Navigator.of(context).pop();
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Feedback queued — token not configured')),
+          );
+        }
+        return;
+      }
+
+      try {
+        final imageUrl = await widget.client.uploadImage(item.id, annotatedPng);
+        final issueUrl = await widget.client.createIssue(
+            item.description, imageUrl);
+        await widget.queue.markUploaded(item.id, issueUrl);
+        if (mounted) {
+          Navigator.of(context).pop();
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Feedback submitted — thank you!')),
+          );
+        }
+      } on FeedbackClientException {
+        if (mounted) {
+          Navigator.of(context).pop();
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+                content: Text('Queued — will submit when online')),
+          );
+        }
+      }
+    } finally {
+      if (mounted) setState(() => _isSubmitting = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ModalShell(
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+              'SEND FEEDBACK',
+              style: TextStyle(
+                fontSize: 11,
+                letterSpacing: 2.5,
+                color: Colors.white54,
+              ),
+            ),
+            const SizedBox(height: 12),
+            // Screenshot preview with annotation overlay
+            LayoutBuilder(
+              builder: (context, constraints) {
+                return ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: GestureDetector(
+                    onPanStart: _drawMode
+                        ? (d) => setState(() => _points.add(d.localPosition))
+                        : null,
+                    onPanUpdate: _drawMode
+                        ? (d) => setState(() => _points.add(d.localPosition))
+                        : null,
+                    onPanEnd: _drawMode
+                        ? (_) => setState(() => _points.add(null))
+                        : null,
+                    child: Stack(
+                      children: [
+                        _ImageSizeCapture(
+                          onSizeChanged: (size) {
+                            if (_imageDisplaySize != size) {
+                              setState(() => _imageDisplaySize = size);
+                            }
+                          },
+                          child: Image.memory(
+                            widget.screenshot,
+                            width: constraints.maxWidth,
+                            fit: BoxFit.fitWidth,
+                          ),
+                        ),
+                        if (_imageDisplaySize != Size.zero)
+                          Positioned.fill(
+                            child: CustomPaint(
+                              painter: _AnnotationPainter(_points),
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            ),
+            const SizedBox(height: 8),
+            // Draw mode toggle
+            Row(
+              children: [
+                IconButton(
+                  onPressed: () => setState(() => _drawMode = !_drawMode),
+                  icon: Icon(
+                    Icons.edit,
+                    size: 18,
+                    color: _drawMode ? kLyraAccent : Colors.white54,
+                  ),
+                ),
+                if (_points.isNotEmpty)
+                  IconButton(
+                    onPressed: () => setState(() => _points.clear()),
+                    icon: const Icon(Icons.clear, size: 18, color: Colors.white54),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            // Description
+            TextField(
+              controller: _descriptionController,
+              maxLines: 3,
+              style: const TextStyle(fontSize: 13, color: Colors.white),
+              decoration: InputDecoration(
+                hintText: 'Describe the issue...',
+                hintStyle: TextStyle(
+                    color: Colors.white.withValues(alpha: 0.4), fontSize: 13),
+                filled: true,
+                fillColor: kLyraInk,
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  borderSide:
+                      BorderSide(color: Colors.white.withValues(alpha: 0.12)),
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  borderSide:
+                      BorderSide(color: Colors.white.withValues(alpha: 0.12)),
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+            // Privacy disclaimer
+            Text(
+              'Your screenshot may include game data. Submitted feedback is publicly visible as a GitHub issue.',
+              style: TextStyle(
+                  fontSize: 10, color: Colors.white.withValues(alpha: 0.4)),
+            ),
+            const SizedBox(height: 12),
+            // Buttons
+            Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton(
+                    onPressed:
+                        _isSubmitting ? null : () => Navigator.of(context).pop(),
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: Colors.white,
+                      side: BorderSide(
+                          color: Colors.white.withValues(alpha: 0.2)),
+                      shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(100)),
+                    ),
+                    child: const Text('Cancel'),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: _isSubmitting ? null : _submit,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: kLyraAccent,
+                      foregroundColor: kLyraInk,
+                      shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(100)),
+                    ),
+                    child: _isSubmitting
+                        ? const SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Text('Submit'),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ImageSizeCapture extends StatefulWidget {
+  final Widget child;
+  final ValueChanged<Size> onSizeChanged;
+
+  const _ImageSizeCapture({required this.child, required this.onSizeChanged});
+
+  @override
+  State<_ImageSizeCapture> createState() => _ImageSizeCaptureState();
+}
+
+class _ImageSizeCaptureState extends State<_ImageSizeCapture> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _reportSize());
+  }
+
+  void _reportSize() {
+    final box = context.findRenderObject() as RenderBox?;
+    if (box != null && box.hasSize) {
+      widget.onSizeChanged(box.size);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}
+
+class _AnnotationPainter extends CustomPainter {
+  final List<Offset?> points;
+
+  _AnnotationPainter(this.points);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = kLyraAccent
+      ..strokeWidth = 3.0
+      ..strokeCap = StrokeCap.round
+      ..style = PaintingStyle.stroke;
+
+    for (int i = 0; i < points.length - 1; i++) {
+      if (points[i] != null && points[i + 1] != null) {
+        canvas.drawLine(points[i]!, points[i + 1]!, paint);
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _AnnotationPainter oldDelegate) => true;
+}

--- a/lib/widgets/feedback_modal.dart
+++ b/lib/widgets/feedback_modal.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
+import '../core/logger.dart';
 import '../game/theme/app_theme.dart';
 import '../models/feedback_item.dart';
 import '../screens/modals.dart';
@@ -45,7 +46,9 @@ class _FeedbackModalState extends State<FeedbackModal> {
     final canvas = Canvas(recorder);
     canvas.drawImage(image, Offset.zero, Paint());
 
-    if (_points.isNotEmpty) {
+    if (_points.isNotEmpty &&
+        _imageDisplaySize.width > 0 &&
+        _imageDisplaySize.height > 0) {
       final paint = Paint()
         ..color = kLyraAccent
         ..strokeWidth = 3.0
@@ -54,7 +57,9 @@ class _FeedbackModalState extends State<FeedbackModal> {
 
       for (int i = 0; i < _points.length - 1; i++) {
         if (_points[i] != null && _points[i + 1] != null) {
-          // Scale points from widget coordinates to image coordinates
+          // Scale annotation points from widget-display coordinates to image-pixel
+          // coordinates. Precondition: _imageDisplaySize must be non-zero (guaranteed
+          // because _submit is only reachable after the modal has laid out).
           final scaleX = image.width / _imageDisplaySize.width;
           final scaleY = image.height / _imageDisplaySize.height;
           canvas.drawLine(
@@ -73,7 +78,11 @@ class _FeedbackModalState extends State<FeedbackModal> {
         await rendered.toByteData(format: ui.ImageByteFormat.png);
     image.dispose();
     rendered.dispose();
-    return byteData!.buffer.asUint8List();
+    if (byteData == null) {
+      gameLogger.w('_renderAnnotatedScreenshot: toByteData returned null');
+      throw StateError('Failed to encode annotated screenshot to PNG');
+    }
+    return byteData.buffer.asUint8List();
   }
 
   Size _imageDisplaySize = Size.zero;
@@ -122,6 +131,14 @@ class _FeedbackModalState extends State<FeedbackModal> {
                 content: Text('Queued — will submit when online')),
           );
         }
+      }
+    } catch (e, stack) {
+      gameLogger.w('FeedbackModal._submit failed', error: e, stackTrace: stack);
+      if (mounted) {
+        Navigator.of(context).pop();
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Failed to prepare feedback — please try again')),
+        );
       }
     } finally {
       if (mounted) setState(() => _isSubmitting = false);
@@ -281,6 +298,9 @@ class _FeedbackModalState extends State<FeedbackModal> {
   }
 }
 
+/// Helper that measures its rendered size after layout and forwards it via
+/// [onSizeChanged]. Used to map annotation [Offset] points (in widget space)
+/// to the correct scale for the underlying image pixels.
 class _ImageSizeCapture extends StatefulWidget {
   final Widget child;
   final ValueChanged<Size> onSizeChanged;
@@ -330,5 +350,6 @@ class _AnnotationPainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(covariant _AnnotationPainter oldDelegate) => true;
+  bool shouldRepaint(covariant _AnnotationPainter oldDelegate) =>
+      !identical(points, oldDelegate.points);
 }

--- a/lib/widgets/feedback_modal.dart
+++ b/lib/widgets/feedback_modal.dart
@@ -55,13 +55,10 @@ class _FeedbackModalState extends State<FeedbackModal> {
         ..strokeCap = StrokeCap.round
         ..style = PaintingStyle.stroke;
 
+      final scaleX = image.width / _imageDisplaySize.width;
+      final scaleY = image.height / _imageDisplaySize.height;
       for (int i = 0; i < _points.length - 1; i++) {
         if (_points[i] != null && _points[i + 1] != null) {
-          // Scale annotation points from widget-display coordinates to image-pixel
-          // coordinates. Precondition: _imageDisplaySize must be non-zero (guaranteed
-          // because _submit is only reachable after the modal has laid out).
-          final scaleX = image.width / _imageDisplaySize.width;
-          final scaleY = image.height / _imageDisplaySize.height;
           canvas.drawLine(
             Offset(_points[i]!.dx * scaleX, _points[i]!.dy * scaleY),
             Offset(_points[i + 1]!.dx * scaleX, _points[i + 1]!.dy * scaleY),

--- a/lib/widgets/hud_overlay.dart
+++ b/lib/widgets/hud_overlay.dart
@@ -20,7 +20,7 @@ class HudOverlay extends StatelessWidget {
                   child: _StatCard(label: 'SCORE',
                       value: scores.score.toString())),
               const SizedBox(width: 8),
-              Expanded(flex: 1,
+              Expanded(
                   child: _StatCard(label: 'BEST',
                       value: scores.best.toString())),
             ],
@@ -39,7 +39,7 @@ class _StatCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.fromLTRB(12, 10, 12, 10),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
       decoration: BoxDecoration(
         color: const Color(0x0FFFFFFF),
         border: Border.all(color: const Color(0x1AFFFFFF)),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -297,7 +297,7 @@ packages:
     source: hosted
     version: "1.0.2"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
@@ -805,6 +805,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.15.0"
+  workmanager:
+    dependency: "direct main"
+    description:
+      name: workmanager
+      sha256: "065673b2a465865183093806925419d311a9a5e0995aa74ccf8920fd695e2d10"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.0+3"
+  workmanager_android:
+    dependency: transitive
+    description:
+      name: workmanager_android
+      sha256: "9ae744db4ef891f5fcd2fb8671fccc712f4f96489a487a1411e0c8675e5e8cb7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.0+2"
+  workmanager_apple:
+    dependency: transitive
+    description:
+      name: workmanager_apple
+      sha256: "1cc12ae3cbf5535e72f7ba4fde0c12dd11b757caf493a28e22d684052701f2ca"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.1+2"
+  workmanager_platform_interface:
+    dependency: transitive
+    description:
+      name: workmanager_platform_interface
+      sha256: f40422f10b970c67abb84230b44da22b075147637532ac501729256fcea10a47
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.1+1"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,8 @@ dependencies:
   sentry_flutter: ^8.12.0
   package_info_plus: ^9.0.1
   google_fonts: ^6.2.1
+  http: ^1.1.0
+  workmanager: ^0.9.0
 
 dev_dependencies:
   flutter_test:

--- a/test/services/feedback_queue_service_integration_test.dart
+++ b/test/services/feedback_queue_service_integration_test.dart
@@ -1,0 +1,143 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:cosmic_match/models/feedback_item.dart';
+import 'package:cosmic_match/services/feedback_queue_service.dart';
+
+FeedbackItem _item({
+  String id = 'item-1',
+  String description = 'Test feedback',
+  bool uploaded = false,
+  String? githubIssueUrl,
+}) =>
+    FeedbackItem(
+      id: id,
+      timestamp: DateTime(2026, 1, 1),
+      description: description,
+      screenshotBase64:
+          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+      uploaded: uploaded,
+      githubIssueUrl: githubIssueUrl,
+    );
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('hive_feedback_test_');
+    Hive.init(tempDir.path);
+  });
+
+  tearDown(() async {
+    await Hive.close();
+    await tempDir.delete(recursive: true);
+  });
+
+  group('FeedbackQueueService integration', () {
+    test('enqueue → loadQueue round-trip preserves all fields', () async {
+      final service = FeedbackQueueService();
+      final original = _item(description: 'Round-trip check');
+      await service.enqueue(original);
+      final queue = await service.loadQueue();
+      expect(queue, hasLength(1));
+      expect(queue.first.id, original.id);
+      expect(queue.first.description, original.description);
+      expect(queue.first.screenshotBase64, original.screenshotBase64);
+      expect(queue.first.uploaded, isFalse);
+      expect(queue.first.githubIssueUrl, isNull);
+    });
+
+    test('loadQueue returns empty list when no items enqueued', () async {
+      final service = FeedbackQueueService();
+      final queue = await service.loadQueue();
+      expect(queue, isEmpty);
+    });
+
+    test('enqueue multiple items — all returned by loadQueue', () async {
+      final service = FeedbackQueueService();
+      await service.enqueue(_item(id: 'a', description: 'First'));
+      await service.enqueue(_item(id: 'b', description: 'Second'));
+      await service.enqueue(_item(id: 'c', description: 'Third'));
+      final queue = await service.loadQueue();
+      expect(queue, hasLength(3));
+      final ids = queue.map((i) => i.id).toSet();
+      expect(ids, containsAll(['a', 'b', 'c']));
+    });
+
+    test('loadQueue skips items with tampered CRC', () async {
+      final service = FeedbackQueueService();
+      // Directly write a tampered entry into the box
+      final box = await Hive.openBox('feedback_queue');
+      await box.put('tampered-1', {
+        'id': 'tampered-1',
+        'timestamp': DateTime(2026, 1, 1).toIso8601String(),
+        'description': 'hacked',
+        'screenshotBase64': 'abc',
+        'uploaded': true,
+        'githubIssueUrl': null,
+        'crc': 0,
+      });
+      await box.close();
+
+      final queue = await service.loadQueue();
+      expect(queue, isEmpty);
+    });
+
+    test('markUploaded updates uploaded flag and sets issueUrl', () async {
+      final service = FeedbackQueueService();
+      await service.enqueue(_item(id: 'up-1'));
+
+      await service.markUploaded('up-1', 'https://github.com/issues/42');
+
+      final queue = await service.loadQueue();
+      expect(queue, hasLength(1));
+      expect(queue.first.uploaded, isTrue);
+      expect(queue.first.githubIssueUrl, 'https://github.com/issues/42');
+    });
+
+    test('markUploaded preserves other fields unchanged', () async {
+      final service = FeedbackQueueService();
+      final original = _item(id: 'up-2', description: 'Preserve me');
+      await service.enqueue(original);
+
+      await service.markUploaded('up-2', 'https://github.com/issues/99');
+
+      final queue = await service.loadQueue();
+      final item = queue.first;
+      expect(item.description, original.description);
+      expect(item.screenshotBase64, original.screenshotBase64);
+      expect(item.id, original.id);
+    });
+
+    test('markUploaded on unknown id is a no-op', () async {
+      final service = FeedbackQueueService();
+      await service.enqueue(_item(id: 'real-1'));
+      // Should not throw or corrupt the queue
+      await service.markUploaded('nonexistent', 'https://github.com/issues/1');
+      final queue = await service.loadQueue();
+      expect(queue, hasLength(1));
+      expect(queue.first.id, 'real-1');
+    });
+
+    test('remove deletes the correct item', () async {
+      final service = FeedbackQueueService();
+      await service.enqueue(_item(id: 'del-1', description: 'Delete me'));
+      await service.enqueue(_item(id: 'keep-1', description: 'Keep me'));
+
+      await service.remove('del-1');
+
+      final queue = await service.loadQueue();
+      expect(queue, hasLength(1));
+      expect(queue.first.id, 'keep-1');
+    });
+
+    test('remove on unknown id is a no-op', () async {
+      final service = FeedbackQueueService();
+      await service.enqueue(_item(id: 'item-1'));
+      await service.remove('nonexistent');
+      final queue = await service.loadQueue();
+      expect(queue, hasLength(1));
+    });
+  });
+}

--- a/test/services/feedback_queue_service_test.dart
+++ b/test/services/feedback_queue_service_test.dart
@@ -1,0 +1,118 @@
+import 'package:archive/archive.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cosmic_match/models/feedback_item.dart';
+
+/// Mirror of FeedbackQueueService._isValid for test-level validation.
+bool _isValid(Map raw) {
+  final storedCrc = raw['crc'] as int?;
+  if (storedCrc == null) return false;
+  final data = Map<String, dynamic>.from(raw)..remove('crc');
+  return getCrc32(FeedbackItem.canonicalize(data).codeUnits) == storedCrc;
+}
+
+FeedbackItem _createItem({
+  String id = 'test-1',
+  String description = 'Test feedback',
+  bool uploaded = false,
+  String? githubIssueUrl,
+}) {
+  return FeedbackItem(
+    id: id,
+    timestamp: DateTime(2026, 1, 1),
+    description: description,
+    screenshotBase64: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+    uploaded: uploaded,
+    githubIssueUrl: githubIssueUrl,
+  );
+}
+
+void main() {
+  group('FeedbackItem', () {
+    test('toMap includes crc key', () {
+      final item = _createItem();
+      final map = item.toMap();
+      expect(map.containsKey('crc'), isTrue);
+      expect(map['crc'], isA<int>());
+    });
+
+    test('fromMap round-trips correctly', () {
+      final original = _createItem(description: 'A bug report');
+      final map = original.toMap();
+      final restored = FeedbackItem.fromMap(map);
+      expect(restored.id, original.id);
+      expect(restored.description, original.description);
+      expect(restored.screenshotBase64, original.screenshotBase64);
+      expect(restored.uploaded, original.uploaded);
+      expect(restored.githubIssueUrl, original.githubIssueUrl);
+    });
+
+    test('crc is stable across repeated toMap calls', () {
+      final item = _createItem();
+      final crc1 = item.toMap()['crc'] as int;
+      final crc2 = item.toMap()['crc'] as int;
+      expect(crc1, equals(crc2));
+    });
+
+    test('copyWith updates uploaded and preserves other fields', () {
+      final item = _createItem();
+      final updated = item.copyWith(
+          uploaded: true, githubIssueUrl: 'https://github.com/test/1');
+      expect(updated.uploaded, isTrue);
+      expect(updated.githubIssueUrl, 'https://github.com/test/1');
+      expect(updated.id, item.id);
+      expect(updated.description, item.description);
+    });
+  });
+
+  group('FeedbackItem CRC validation', () {
+    test('valid CRC passes validation', () {
+      final item = _createItem();
+      final map = item.toMap();
+      expect(_isValid(map), isTrue);
+    });
+
+    test('missing crc key treated as tampered', () {
+      final item = _createItem();
+      final map = item.toMap()..remove('crc');
+      expect(_isValid(map), isFalse);
+    });
+
+    test('tampered description is detected', () {
+      final item = _createItem();
+      final map = item.toMap();
+      map['description'] = 'hacked';
+      expect(_isValid(map), isFalse);
+    });
+
+    test('tampered uploaded flag is detected', () {
+      final item = _createItem();
+      final map = item.toMap();
+      map['uploaded'] = true;
+      expect(_isValid(map), isFalse);
+    });
+
+    test('wrong crc value is detected', () {
+      final item = _createItem();
+      final map = item.toMap();
+      map['crc'] = 0;
+      expect(_isValid(map), isFalse);
+    });
+
+    test('CRC is order-independent (canonicalization)', () {
+      final item = _createItem();
+      final canonical = item.toMap();
+
+      // Reconstruct with different key order
+      final reordered = <String, dynamic>{
+        'crc': canonical['crc'],
+        'screenshotBase64': canonical['screenshotBase64'],
+        'description': canonical['description'],
+        'id': canonical['id'],
+        'timestamp': canonical['timestamp'],
+        'uploaded': canonical['uploaded'],
+        'githubIssueUrl': canonical['githubIssueUrl'],
+      };
+      expect(_isValid(reordered), isTrue);
+    });
+  });
+}

--- a/test/services/github_feedback_client_test.dart
+++ b/test/services/github_feedback_client_test.dart
@@ -1,0 +1,136 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:cosmic_match/services/github_feedback_client.dart';
+
+// 1x1 transparent PNG (smallest valid PNG)
+final Uint8List _minimalPng = base64Decode(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==');
+
+void main() {
+  group('GitHubFeedbackClient — token guard', () {
+    test('isAvailable returns false when no token is compiled in', () {
+      final client = GitHubFeedbackClient();
+      expect(client.isAvailable, isFalse);
+    });
+
+    test('uploadImage throws FeedbackClientException when token is empty', () {
+      final client = GitHubFeedbackClient();
+      expect(
+        () => client.uploadImage('test-id', _minimalPng),
+        throwsA(isA<FeedbackClientException>()),
+      );
+    });
+
+    test('createIssue throws FeedbackClientException when token is empty', () {
+      final client = GitHubFeedbackClient();
+      expect(
+        () => client.createIssue('description', 'https://example.com/img.png'),
+        throwsA(isA<FeedbackClientException>()),
+      );
+    });
+
+    test('isAvailable returns true when token is non-empty', () {
+      final client = GitHubFeedbackClient.withToken('ghp_test123');
+      expect(client.isAvailable, isTrue);
+    });
+  });
+
+  group('GitHubFeedbackClient — HTTP responses', () {
+    test('uploadImage returns download_url on 201', () async {
+      final mockHttp = MockClient((request) async {
+        expect(request.method, 'PUT');
+        expect(request.url.path, contains('docs/feedback/img-1.png'));
+        return http.Response(
+          jsonEncode({
+            'content': {
+              'download_url': 'https://raw.githubusercontent.com/test/img.png'
+            },
+          }),
+          201,
+        );
+      });
+
+      final client = GitHubFeedbackClient.withToken('ghp_test', httpClient: mockHttp);
+      final url = await client.uploadImage('img-1', _minimalPng);
+      expect(url, 'https://raw.githubusercontent.com/test/img.png');
+    });
+
+    test('uploadImage throws FeedbackClientException on 403', () async {
+      final mockHttp = MockClient((_) async =>
+          http.Response('{"message":"Bad credentials"}', 403));
+
+      final client = GitHubFeedbackClient.withToken('ghp_bad', httpClient: mockHttp);
+      expect(
+        () => client.uploadImage('img-1', _minimalPng),
+        throwsA(isA<FeedbackClientException>().having(
+          (e) => e.message,
+          'message',
+          contains('403'),
+        )),
+      );
+    });
+
+    test('uploadImage throws FeedbackClientException on 422', () async {
+      final mockHttp = MockClient((_) async =>
+          http.Response('{"message":"Unprocessable Entity"}', 422));
+
+      final client = GitHubFeedbackClient.withToken('ghp_test', httpClient: mockHttp);
+      expect(
+        () => client.uploadImage('img-1', _minimalPng),
+        throwsA(isA<FeedbackClientException>()),
+      );
+    });
+
+    test('createIssue returns html_url on 201', () async {
+      final mockHttp = MockClient((request) async {
+        expect(request.method, 'POST');
+        expect(request.url.path, contains('/issues'));
+        final body = jsonDecode(request.body) as Map<String, dynamic>;
+        expect(body['title'], 'In-app feedback');
+        expect(body['body'], contains('A bug'));
+        return http.Response(
+          jsonEncode({'html_url': 'https://github.com/alexsiri7/cosmic-match/issues/1'}),
+          201,
+        );
+      });
+
+      final client = GitHubFeedbackClient.withToken('ghp_test', httpClient: mockHttp);
+      final url = await client.createIssue('A bug', 'https://img.png');
+      expect(url, 'https://github.com/alexsiri7/cosmic-match/issues/1');
+    });
+
+    test('createIssue throws FeedbackClientException on 403', () async {
+      final mockHttp = MockClient((_) async =>
+          http.Response('{"message":"Bad credentials"}', 403));
+
+      final client = GitHubFeedbackClient.withToken('ghp_bad', httpClient: mockHttp);
+      expect(
+        () => client.createIssue('desc', 'https://img.png'),
+        throwsA(isA<FeedbackClientException>().having(
+          (e) => e.message,
+          'message',
+          contains('403'),
+        )),
+      );
+    });
+
+    test('createIssue sends Authorization header', () async {
+      http.BaseRequest? capturedRequest;
+      final mockHttp = MockClient((request) async {
+        capturedRequest = request;
+        return http.Response(
+          jsonEncode({'html_url': 'https://github.com/issues/1'}),
+          201,
+        );
+      });
+
+      final client = GitHubFeedbackClient.withToken('ghp_secret', httpClient: mockHttp);
+      await client.createIssue('test', 'https://img.png');
+      expect(capturedRequest?.headers['Authorization'], 'token ghp_secret');
+    });
+  });
+}

--- a/test/widgets/feedback_modal_test.dart
+++ b/test/widgets/feedback_modal_test.dart
@@ -1,0 +1,107 @@
+import 'dart:convert';
+import 'dart:typed_data';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cosmic_match/widgets/feedback_modal.dart';
+import 'package:cosmic_match/services/feedback_queue_service.dart';
+import 'package:cosmic_match/services/github_feedback_client.dart';
+
+// 1x1 transparent PNG (smallest valid PNG)
+final Uint8List _kTestPng = base64Decode(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==');
+
+void main() {
+  group('FeedbackModal', () {
+    testWidgets('renders screenshot preview and text field', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: FeedbackModal(
+              screenshot: _kTestPng,
+              queue: FeedbackQueueService(cipher: null),
+              client: GitHubFeedbackClient(),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('SEND FEEDBACK'), findsOneWidget);
+      expect(find.byType(TextField), findsOneWidget);
+      expect(find.byType(CustomPaint), findsWidgets);
+    });
+
+    testWidgets('has Cancel and Submit buttons', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: FeedbackModal(
+              screenshot: _kTestPng,
+              queue: FeedbackQueueService(cipher: null),
+              client: GitHubFeedbackClient(),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Cancel'), findsOneWidget);
+      expect(find.text('Submit'), findsOneWidget);
+    });
+
+    testWidgets('has draw mode toggle', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: FeedbackModal(
+              screenshot: _kTestPng,
+              queue: FeedbackQueueService(cipher: null),
+              client: GitHubFeedbackClient(),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.edit), findsOneWidget);
+    });
+
+    testWidgets('shows privacy disclaimer', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: FeedbackModal(
+              screenshot: _kTestPng,
+              queue: FeedbackQueueService(cipher: null),
+              client: GitHubFeedbackClient(),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.textContaining('publicly visible'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('text field accepts input', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: FeedbackModal(
+              screenshot: _kTestPng,
+              queue: FeedbackQueueService(cipher: null),
+              client: GitHubFeedbackClient(),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), 'Bug: tiles overlap');
+      expect(find.text('Bug: tiles overlap'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds a zero-friction in-app feedback flow that lets players report bugs and request features directly from Cosmic Match. A "Send feedback" button on HomeScreen and a mail-icon circle button in GameScreen capture the current screen, open a bottom-sheet annotation canvas, and submit the annotated screenshot as a GitHub issue on `alexsiri7/cosmic-match`. Submissions are queued locally when offline and retried on reconnect via WorkManager.

Fixes #80

## Changes

### New files
- `lib/models/feedback_item.dart` — immutable `FeedbackItem` model with `toMap`/`fromMap`/`canonicalize`/CRC32 (mirrors `LevelProgress` pattern)
- `lib/services/feedback_queue_service.dart` — Hive-backed encrypted offline queue (mirrors `ProgressService`)
- `lib/services/github_feedback_client.dart` — uploads PNG via GitHub Contents API, creates issue via Issues API; reads token from `String.fromEnvironment('GITHUB_FEEDBACK_TOKEN')`
- `lib/widgets/feedback_modal.dart` — bottom sheet with screenshot preview, `CustomPaint` annotation canvas, description `TextField`, cancel/submit
- `test/services/feedback_queue_service_test.dart` — unit tests: enqueue, remove, markUploaded, CRC rejection, empty queue
- `test/widgets/feedback_modal_test.dart` — widget tests: renders, annotation canvas, text field, submit/cancel

### Updated files
- `pubspec.yaml` / `pubspec.lock` — added `http: ^1.1.0`, `workmanager: ^0.9.0`
- `lib/screens/home_screen.dart` — "Send feedback" TextButton below Galaxy Map button
- `lib/screens/game_screen.dart` — mail-icon circle button in HUD top row; app-level `RepaintBoundary` for screenshot capture
- `lib/main.dart` — initialises `FeedbackQueueService` + `GitHubFeedbackClient`; wires `onFeedback` callbacks; registers WorkManager retry task
- `.github/workflows/ci.yml` — injects `GITHUB_FEEDBACK_TOKEN` secret via `--dart-define` in all build steps

## Deviations from plan

| Deviation | Reason |
|-----------|--------|
| `workmanager: ^0.9.0` instead of `^0.5.7` | 0.5.7 does not exist on pub.dev |
| App-level `RepaintBoundary` for all screenshots | `_GameScreenState` is private; app-level boundary captures full screen including HUD, giving more context |
| `onMap` on HomeScreen is a no-op | `MapScreen` does not yet exist in the codebase |
| `// ignore: deprecated_member_use` on `isInDebugMode` | Parameter deprecated in workmanager 0.9.x; suppressed to avoid blocking |

## Validation

| Check | Result |
|-------|--------|
| `flutter analyze` | ✅ No issues |
| `flutter test` | ✅ 152 passed (137 existing + 15 new), 0 failed |
| `flutter build apk --debug` | ⚠️ Pre-existing failure — Java 25.0.2 incompatible with Kotlin Gradle plugin on this machine; reproduces on `main` with no changes |

## Security notes

- `GITHUB_FEEDBACK_TOKEN` is read via `String.fromEnvironment` (compile-time constant) and **never logged**
- Token must be added to repo secrets (`Settings → Secrets → Actions → GITHUB_FEEDBACK_TOKEN`) with `contents: write` + `issues: write` scopes on `alexsiri7/cosmic-match`
- Feedback submissions are publicly visible as GitHub issues; the modal displays a privacy disclaimer
- Offline queue uses the same Hive AES cipher and CRC32 integrity validation as `ProgressService`

## Test plan

- [ ] Tap "Send feedback" on HomeScreen → screenshot captured → `FeedbackModal` opens
- [ ] Draw annotation strokes on screenshot preview
- [ ] Enter description text and tap Submit → GitHub issue created with `feedback` label and inline screenshot
- [ ] Submit while offline → "Queued" snackbar shown → issue created on reconnect
- [ ] Leave `GITHUB_FEEDBACK_TOKEN` empty → "Feedback unavailable" snackbar, no crash
- [ ] Existing HomeScreen → GameScreen → Back flow unchanged
- [ ] All game mechanics and visuals unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)