### PR TITLE
fix: prevent refill tile overlap by spawning above board top

### DIFF
--- a/lib/game/match3_game.dart
+++ b/lib/game/match3_game.dart
@@ -85,7 +85,6 @@ class Match3Game extends FlameGame<GridWorld> with RiverpodGameMixin {
       return;
     }
 
-    // Check adjacency
     final dx = (tile.gridX - _selectedTile!.gridX).abs();
     final dy = (tile.gridY - _selectedTile!.gridY).abs();
     if (dx + dy != 1) {

--- a/lib/game/world/grid_world.dart
+++ b/lib/game/world/grid_world.dart
@@ -296,14 +296,14 @@ class GridWorld extends World {
             gridX: x,
             gridY: y,
             tileType: grid[x][y]!,
-            position: _tilePosition(x, y - 1), // start one row above
+            position: _tilePosition(x, -1), // always spawn above the board top
             size: Vector2.all(tileSize - 2),
           );
           tiles[x][y] = tile;
           add(tile);
           tile.add(MoveEffect.to(
             _tilePosition(x, y),
-            EffectController(duration: 0.25),
+            EffectController(duration: 0.035 * (y + 1)),
           ));
         }
       }

--- a/lib/widgets/hud_overlay.dart
+++ b/lib/widgets/hud_overlay.dart
@@ -31,6 +31,9 @@ class HudOverlay extends StatelessWidget {
   }
 }
 
+const _kCardFill = Color(0x0FFFFFFF);   // 6% white fill
+const _kCardBorder = Color(0x1AFFFFFF); // 10% white border
+
 class _StatCard extends StatelessWidget {
   final String label;
   final String value;
@@ -41,8 +44,8 @@ class _StatCard extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.fromLTRB(12, 10, 12, 10),
       decoration: BoxDecoration(
-        color: const Color(0x0FFFFFFF),
-        border: Border.all(color: const Color(0x1AFFFFFF)),
+        color: _kCardFill,
+        border: Border.all(color: _kCardBorder),
         borderRadius: BorderRadius.circular(12),
       ),
       child: Column(

--- a/test/game/flame_refill_placement_test.dart
+++ b/test/game/flame_refill_placement_test.dart
@@ -87,8 +87,7 @@ void main() {
         final gameSize = Vector2(400, 800);
         world.initLayoutForTest(gameSize);
 
-        // The refill animation starts tiles at _tilePosition(x, y - 1)
-        // For row 0, that's _tilePosition(x, -1) which should be above row 0
+        // The refill animation always starts tiles at _tilePosition(x, -1) — above the board top
         final aboveRow0 = world.tilePositionAt(0, -1);
         final row0 = world.tilePositionAt(0, 0);
         expect(aboveRow0.y, lessThan(row0.y),
@@ -97,6 +96,25 @@ void main() {
         expect(row0.y - aboveRow0.y, closeTo(world.tileSize, _epsilon));
         // Same x coordinate
         expect(aboveRow0.x, closeTo(row0.x, _epsilon));
+      },
+    );
+
+    testWithGame<FlameGame>(
+      'refill tiles for all target rows spawn above the board',
+      () => FlameGame(world: _TestGridWorld()),
+      (game) async {
+        final world = game.world as _TestGridWorld;
+        world.grid = List.generate(
+            GridWorld.cols, (_) => List.generate(GridWorld.rows, (_) => null));
+        final gameSize = Vector2(400, 800);
+        world.initLayoutForTest(gameSize);
+
+        final aboveBoard = world.tilePositionAt(0, -1);
+        final topRow = world.tilePositionAt(0, 0);
+
+        // Spawn position must always be above row 0, regardless of target row
+        expect(aboveBoard.y, lessThan(topRow.y),
+            reason: 'Spawn at y=-1 must be above the top visible row for every refill tile');
       },
     );
   });

--- a/test/game/flame_refill_placement_test.dart
+++ b/test/game/flame_refill_placement_test.dart
@@ -100,7 +100,7 @@ void main() {
     );
 
     testWithGame<FlameGame>(
-      'refill tiles for all target rows spawn above the board',
+      'refill tiles for all target rows spawn above the board top regardless of target row',
       () => FlameGame(world: _TestGridWorld()),
       (game) async {
         final world = game.world as _TestGridWorld;
@@ -109,13 +109,28 @@ void main() {
         final gameSize = Vector2(400, 800);
         world.initLayoutForTest(gameSize);
 
-        final aboveBoard = world.tilePositionAt(0, -1);
-        final topRow = world.tilePositionAt(0, 0);
+        final spawnY = world.tilePositionAt(0, -1).y;
 
-        // Spawn position must always be above row 0, regardless of target row
-        expect(aboveBoard.y, lessThan(topRow.y),
-            reason: 'Spawn at y=-1 must be above the top visible row for every refill tile');
+        // Every target row must have its spawn position above the top visible row.
+        // This guards against reintroducing y-relative spawn (the original bug):
+        // the old code used _tilePosition(x, y - 1), so rows y=1..7 would have
+        // spawned inside the board at rows 0..6 respectively.
+        for (int y = 0; y < GridWorld.rows; y++) {
+          final targetY = world.tilePositionAt(0, y).y;
+          expect(spawnY, lessThan(targetY),
+              reason: 'Spawn at y=-1 must be above target row $y');
+        }
       },
     );
+
+    test('refill animation worst-case duration is under cascade await threshold', () {
+      // Cascade await in _runCascade is 300 ms.
+      // Duration for the deepest row (y = rows - 1): 0.035 * rows seconds.
+      const cascadeAwaitSeconds = 0.300;
+      final worstCase = 0.035 * GridWorld.rows;
+      expect(worstCase, lessThan(cascadeAwaitSeconds),
+          reason:
+              'Refill animation must complete before cascade restarts (worst case: ${worstCase * 1000} ms < ${cascadeAwaitSeconds * 1000} ms)');
+    });
   });
 }


### PR DESCRIPTION
## Summary

Refill tiles were spawning at `_tilePosition(x, y - 1)` — one grid row above their *target* row — which for any target row `y ≥ 1` placed them inside the visible 8×8 board, overlapping the tile that gravity had just settled there. The `MoveEffect` then slid the tile down only one row, producing the visible overshoot/overlap on every match clear.

**Root cause**: The spawn offset was relative to the target row instead of always being above the top of the board.

## Changes

- **`lib/game/world/grid_world.dart` line 299** — changed spawn position from `_tilePosition(x, y - 1)` to `_tilePosition(x, -1)` so all refill tiles enter from off-screen above row 0, regardless of their target row.
- **`lib/game/world/grid_world.dart` line 306** — scaled animation duration from a fixed `0.25 s` to `0.035 * (y + 1)` seconds so tiles travelling more rows still fall at a consistent visual speed (row 0 → ~35 ms, row 7 → ~280 ms). Worst-case 280 ms stays under the 300 ms cascade await, so no timing changes are needed elsewhere.
- **`test/game/flame_refill_placement_test.dart`** — updated stale comment that documented the old buggy formula, and added a regression test asserting that the spawn position is above the board top for all target rows.

## Validation

| Check | Result |
|-------|--------|
| `flutter analyze` | ✅ No issues found |
| `flutter test` | ✅ 160 passed, 0 failed |
| `flutter build apk --debug` | ✅ Compiled successfully |

All checks passed without requiring any fixes after implementation.

Fixes #79