### PR TITLE
feat: wire HomeScreen as app entry point and add MapScreen stub

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,10 +31,15 @@ flutter pub get
 lib/
   game/           # Flame game, FSM, world, components
                   #   Input/FSM enums (GamePhase, SwipeDirection) defined in match3_game.dart
-    theme/        # Tile color palette constants (kTilePalette — derived from TileType.colorValue;
-                  #   kTileGlowPalette — derived from TileType.glowValue, used for selection border;
-                  #   kTileSelectedOverlay — transparent, selection drawn by _GlowBorder stroke;
-                  #   cosmic_theme.dart — Lyra galaxy tokens: kCosmicInk, kCosmicNebulaA/B, kCosmicAccent, kBoardBackdrop, kGridLine)
+    theme/        # Color palette and theme tokens
+                  #   Tile palette constants: kTilePalette (TileType.colorValue),
+                  #     kTileGlowPalette (TileType.glowValue, selection border),
+                  #     kTileSelectedOverlay (transparent; selection drawn by _GlowBorder stroke)
+                  #   cosmic_theme.dart — game-layer Lyra tokens: kCosmicInk, kCosmicNebulaA/B,
+                  #     kCosmicAccent, kBoardBackdrop, kGridLine (used in grid_world.dart)
+                  #   app_theme.dart — Flutter shell tokens: kLyraInk (bg), kLyraAccent (accent),
+                  #     kLyraNebulaA/B (nebula gradients), kLyraStroke, kLyraWarning;
+                  #     cosmicTheme() → MaterialApp.theme entry point (used in screens/)
   models/         # Pure data: Score, TileType, LevelProgress
   screens/        # Flutter screens: HomeScreen, MapScreen, GameScreen, modals
                   # Navigation: _Screen enum + _buildScreen() in main.dart

--- a/lib/game/theme/app_theme.dart
+++ b/lib/game/theme/app_theme.dart
@@ -9,13 +9,18 @@ const Color kLyraAccent = Color(0xFFC070E8);
 const Color kLyraStroke = Color(0xFF6A55A8);
 const Color kLyraWarning = Color(0xFFF08A3E); // orange alert tone
 
-final ThemeData _cosmicTheme = ThemeData.dark().copyWith(
-  scaffoldBackgroundColor: kLyraInk,
-  colorScheme: ThemeData.dark().colorScheme.copyWith(
-    surface: kLyraInk,
-    primary: kLyraAccent,
-  ),
-  textTheme: GoogleFonts.ibmPlexMonoTextTheme(ThemeData.dark().textTheme),
-);
+final ThemeData _cosmicTheme = _buildCosmicTheme();
+
+ThemeData _buildCosmicTheme() {
+  final dark = ThemeData.dark();
+  return dark.copyWith(
+    scaffoldBackgroundColor: kLyraInk,
+    colorScheme: dark.colorScheme.copyWith(
+      surface: kLyraInk,
+      primary: kLyraAccent,
+    ),
+    textTheme: GoogleFonts.ibmPlexMonoTextTheme(dark.textTheme),
+  );
+}
 
 ThemeData cosmicTheme() => _cosmicTheme;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,3 @@
-import 'package:flame_riverpod/flame_riverpod.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -7,9 +6,14 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'core/logger.dart';
 import 'game/match3_game.dart';
+import 'game/theme/app_theme.dart';
+import 'screens/game_screen.dart';
+import 'screens/home_screen.dart';
+import 'screens/map_screen.dart';
 import 'services/key_service.dart';
 import 'services/progress_service.dart';
-import 'widgets/hud_overlay.dart';
+
+enum _Screen { home, game, map }
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -67,8 +71,8 @@ class CosmicMatchApp extends StatefulWidget {
 }
 
 class _CosmicMatchAppState extends State<CosmicMatchApp> {
-  final _gameKey = GlobalKey<RiverpodAwareGameWidgetState<Match3Game>>();
   late final Match3Game _game;
+  _Screen _screen = _Screen.home;
 
   @override
   void initState() {
@@ -76,22 +80,28 @@ class _CosmicMatchAppState extends State<CosmicMatchApp> {
     _game = Match3Game(progressService: widget.progressService);
   }
 
+  Widget _buildScreen() {
+    return switch (_screen) {
+      _Screen.home => HomeScreen(
+          onPlay: () => setState(() => _screen = _Screen.game),
+          onMap: () => setState(() => _screen = _Screen.map),
+        ),
+      _Screen.game => GameScreen(
+          game: _game,
+          onBack: () => setState(() => _screen = _Screen.home),
+        ),
+      _Screen.map => MapScreen(
+          onBack: () => setState(() => _screen = _Screen.home),
+        ),
+    };
+  }
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Cosmic Match',
-      theme: ThemeData.dark().copyWith(
-        scaffoldBackgroundColor: const Color(0xFF0D0A1A),
-      ),
-      home: SafeArea(
-        child: RiverpodAwareGameWidget(
-          key: _gameKey,
-          game: _game,
-          overlayBuilderMap: {
-            'hud': (context, game) => HudOverlay(game: game as Match3Game),
-          },
-        ),
-      ),
+      theme: cosmicTheme(),
+      home: _buildScreen(),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -87,6 +87,7 @@ class _CosmicMatchAppState extends State<CosmicMatchApp> {
           onMap: () => setState(() => _screen = _Screen.map),
         ),
       _Screen.game => GameScreen(
+          // V1: single game instance persists across nav; revisit for level-complete flow
           game: _game,
           onBack: () => setState(() => _screen = _Screen.home),
         ),

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import '../game/theme/app_theme.dart';
+
+class MapScreen extends StatelessWidget {
+  final VoidCallback onBack;
+
+  const MapScreen({super.key, required this.onBack});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: kLyraInk,
+      child: SafeArea(
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: IconButton(
+                  onPressed: onBack,
+                  icon: const Icon(Icons.chevron_left, color: Colors.white),
+                ),
+              ),
+            ),
+            Expanded(
+              child: Center(
+                child: Text(
+                  'GALAXY MAP — COMING SOON',
+                  style: GoogleFonts.ibmPlexMono(
+                    fontSize: 11,
+                    letterSpacing: 2,
+                    color: kLyraAccent.withValues(alpha: 0.85),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/hud_overlay.dart
+++ b/lib/widgets/hud_overlay.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import '../game/match3_game.dart';
-import '../game/theme/cosmic_theme.dart';
+import '../game/theme/app_theme.dart';
 
 class HudOverlay extends StatelessWidget {
   final Match3Game game;
@@ -57,7 +57,7 @@ class _StatCard extends StatelessWidget {
           Text(value,
               style: GoogleFonts.ibmPlexMono(
                 fontSize: 20, fontWeight: FontWeight.w500,
-                color: kCosmicAccent)),
+                color: kLyraAccent)),
         ],
       ),
     );

--- a/lib/widgets/hud_overlay.dart
+++ b/lib/widgets/hud_overlay.dart
@@ -3,6 +3,9 @@ import 'package:google_fonts/google_fonts.dart';
 import '../game/match3_game.dart';
 import '../game/theme/app_theme.dart';
 
+const Color _kCardFill = Color(0x0FFFFFFF);
+const Color _kCardBorder = Color(0x1AFFFFFF);
+
 class HudOverlay extends StatelessWidget {
   final Match3Game game;
   const HudOverlay({required this.game, super.key});
@@ -41,8 +44,8 @@ class _StatCard extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.fromLTRB(12, 10, 12, 10),
       decoration: BoxDecoration(
-        color: const Color(0x0FFFFFFF),
-        border: Border.all(color: const Color(0x1AFFFFFF)),
+        color: _kCardFill,
+        border: Border.all(color: _kCardBorder),
         borderRadius: BorderRadius.circular(12),
       ),
       child: Column(

--- a/test/game/cosmic_theme_test.dart
+++ b/test/game/cosmic_theme_test.dart
@@ -1,0 +1,53 @@
+// Tests for cosmicTheme() and the kLyra* color token constants in app_theme.dart.
+// Verifies that the theme is correctly wired to the palette constants so that
+// future token value changes don't silently break the MaterialApp theme.
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:cosmic_match/game/theme/app_theme.dart';
+
+void main() {
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    // Disable runtime font fetching; fonts are not bundled in tests.
+    GoogleFonts.config.allowRuntimeFetching = false;
+  });
+
+  group('cosmicTheme color tokens', () {
+    // Pump a widget that uses cosmicTheme() so the test exercises MaterialApp
+    // theme resolution without triggering the top-level font initialisation
+    // failure outside the widget-test runner.
+    testWidgets('scaffoldBackgroundColor matches kLyraInk', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: cosmicTheme(),
+          home: const SizedBox.shrink(),
+        ),
+      );
+      final theme = Theme.of(tester.element(find.byType(SizedBox)));
+      expect(theme.scaffoldBackgroundColor, kLyraInk);
+    });
+
+    testWidgets('colorScheme.primary matches kLyraAccent', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: cosmicTheme(),
+          home: const SizedBox.shrink(),
+        ),
+      );
+      final theme = Theme.of(tester.element(find.byType(SizedBox)));
+      expect(theme.colorScheme.primary, kLyraAccent);
+    });
+
+    testWidgets('colorScheme.surface matches kLyraInk', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: cosmicTheme(),
+          home: const SizedBox.shrink(),
+        ),
+      );
+      final theme = Theme.of(tester.element(find.byType(SizedBox)));
+      expect(theme.colorScheme.surface, kLyraInk);
+    });
+  });
+}

--- a/test/screens/map_screen_test.dart
+++ b/test/screens/map_screen_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:cosmic_match/screens/map_screen.dart';
+
+void main() {
+  setUpAll(() => GoogleFonts.config.allowRuntimeFetching = false);
+
+  group('MapScreen', () {
+    testWidgets('renders placeholder text', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(home: MapScreen(onBack: () {})),
+      );
+      expect(find.text('GALAXY MAP — COMING SOON'), findsOneWidget);
+    });
+
+    testWidgets('back button invokes onBack callback', (tester) async {
+      var callCount = 0;
+      await tester.pumpWidget(
+        MaterialApp(home: MapScreen(onBack: () => callCount++)),
+      );
+      await tester.tap(find.byIcon(Icons.chevron_left));
+      await tester.pump();
+      expect(callCount, 1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Introduces `_Screen` enum (`home`, `game`, `map`) and `_buildScreen()` in `_CosmicMatchAppState` so the app launches on `HomeScreen` instead of the raw Flame game widget
- Wires `HomeScreen.onPlay` → `GameScreen` and `HomeScreen.onMap` → `MapScreen`
- Adds a minimal `MapScreen` stub so the Galaxy Map button has a destination
- Removes unused `flame_riverpod` / `hud_overlay` imports from `main.dart` (now managed by `GameScreen`)

## Changes

| File | Action | Description |
|------|--------|-------------|
| `lib/main.dart` | Updated | Add `_Screen` enum + `_buildScreen()`; replace raw game widget with `HomeScreen` as `MaterialApp(home:)` |
| `lib/screens/map_screen.dart` | Created | Stub screen with back button matching Lyra galaxy theme |

## Validation

- `flutter analyze` — no issues found
- `flutter test` — 159 passed, 0 failed
- `flutter build apk --debug` — APK compiled successfully

## Notes

The `Match3Game` instance is created once in `initState()` and lives at `_CosmicMatchAppState` level, so game state persists across home ↔ game navigation without re-initialisation.

Build environment note: requires `JAVA_HOME` set to Java 17 (e.g. `JAVA_HOME=/home/asiri/.sdkman/candidates/java/17.0.10-tem`) due to a pre-existing Kotlin/Java 25 incompatibility unrelated to these changes.

Fixes #78