### PR TITLE
refactor: address flame_test review findings (extract helpers, headerHeight constant)

### DIFF
--- a/lib/game/world/grid_world.dart
+++ b/lib/game/world/grid_world.dart
@@ -18,6 +18,12 @@ class GridWorld extends World {
   static const int cols = 8;
   static const int rows = 8;
 
+  /// Fixed height reserved for the HUD/header above the game board (pixels).
+  ///
+  /// Used by [_applyLayout] to compute tile size and board offset. Exported as
+  /// a public constant so tests can reference the same value without hardcoding.
+  static const double headerHeight = 60.0;
+
   final Score score = Score();
   final CascadeController cascade = CascadeController();
   final PatternDetector detector = PatternDetector();
@@ -103,10 +109,10 @@ class GridWorld extends World {
   }
 
   void _applyLayout(Vector2 gameSize) {
-    tileSize = min(gameSize.x / cols, (gameSize.y - 60) / rows);
+    tileSize = min(gameSize.x / cols, (gameSize.y - headerHeight) / rows);
     _boardOffset = Vector2(
       (gameSize.x - tileSize * cols) / 2,
-      60 + (gameSize.y - 60 - tileSize * rows) / 2,
+      headerHeight + (gameSize.y - headerHeight - tileSize * rows) / 2,
     );
   }
 

--- a/test/game/flame_cascade_fsm_test.dart
+++ b/test/game/flame_cascade_fsm_test.dart
@@ -46,8 +46,10 @@ void main() {
       final game = Match3Game(progressService: null);
       expect(game.phase, GamePhase.idle);
 
-      // In debug mode, transitionTo asserts on illegal transitions.
-      // The assert fires before _phase is reset to idle.
+      // flutter test always runs with asserts enabled (debug mode), so
+      // transitionTo() fires the AssertionError before resetting to idle.
+      // In release builds, the assert is absent and the phase silently resets
+      // to idle instead (see CLAUDE.md FSM Transitions invariant).
       expect(
         () => game.transitionTo(GamePhase.cascading),
         throwsA(isA<AssertionError>()),

--- a/test/game/flame_gravity_sync_test.dart
+++ b/test/game/flame_gravity_sync_test.dart
@@ -3,22 +3,15 @@ import 'package:flame_test/flame_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:cosmic_match/game/world/grid_world.dart';
 import 'package:cosmic_match/models/tile_type.dart';
-
-/// Test GridWorld that skips onLoad's Match3Game cast.
-class _TestGridWorld extends GridWorld {
-  @override
-  Future<void> onLoad() async {}
-}
-
-const _epsilon = 0.5;
+import 'test_helpers.dart';
 
 void main() {
   group('GridWorld gravity visual sync', () {
     testWithGame<FlameGame>(
       'single tile falls one row — position updates to new cell',
-      () => FlameGame(world: _TestGridWorld()),
+      () => FlameGame(world: TestGridWorld()),
       (game) async {
-        final world = game.world as _TestGridWorld;
+        final world = game.world as TestGridWorld;
         world.grid = List.generate(
             GridWorld.cols, (_) => List.generate(GridWorld.rows, (_) => null));
         // Place tile at (0, 5) with null below at (0, 6)
@@ -42,9 +35,9 @@ void main() {
 
     testWithGame<FlameGame>(
       'tile settles to bottom row — position matches last row',
-      () => FlameGame(world: _TestGridWorld()),
+      () => FlameGame(world: TestGridWorld()),
       (game) async {
-        final world = game.world as _TestGridWorld;
+        final world = game.world as TestGridWorld;
         world.grid = List.generate(
             GridWorld.cols, (_) => List.generate(GridWorld.rows, (_) => null));
         world.grid[3][0] = TileType.yellow;
@@ -59,15 +52,15 @@ void main() {
         final topPos = world.tilePositionAt(3, 0);
         // Bottom row should be (rows-1) * tileSize below the top row
         expect(expected.y - topPos.y,
-            closeTo((GridWorld.rows - 1) * world.tileSize, _epsilon));
+            closeTo((GridWorld.rows - 1) * world.tileSize, kTestEpsilon));
       },
     );
 
     testWithGame<FlameGame>(
       'column of tiles preserves relative order — vertical spacing is tileSize',
-      () => FlameGame(world: _TestGridWorld()),
+      () => FlameGame(world: TestGridWorld()),
       (game) async {
-        final world = game.world as _TestGridWorld;
+        final world = game.world as TestGridWorld;
         world.grid = List.generate(
             GridWorld.cols, (_) => List.generate(GridWorld.rows, (_) => null));
         // Place 3 tiles in column 2: rows 0, 1, 2
@@ -89,11 +82,11 @@ void main() {
         final pos5 = world.tilePositionAt(2, 5);
         final pos6 = world.tilePositionAt(2, 6);
         final pos7 = world.tilePositionAt(2, 7);
-        expect(pos6.y - pos5.y, closeTo(world.tileSize, _epsilon));
-        expect(pos7.y - pos6.y, closeTo(world.tileSize, _epsilon));
+        expect(pos6.y - pos5.y, closeTo(world.tileSize, kTestEpsilon));
+        expect(pos7.y - pos6.y, closeTo(world.tileSize, kTestEpsilon));
         // Same column — x should match
-        expect(pos5.x, closeTo(pos6.x, _epsilon));
-        expect(pos6.x, closeTo(pos7.x, _epsilon));
+        expect(pos5.x, closeTo(pos6.x, kTestEpsilon));
+        expect(pos6.x, closeTo(pos7.x, kTestEpsilon));
       },
     );
   });

--- a/test/game/flame_refill_placement_test.dart
+++ b/test/game/flame_refill_placement_test.dart
@@ -3,22 +3,15 @@ import 'package:flame_test/flame_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:cosmic_match/game/world/grid_world.dart';
 import 'package:cosmic_match/models/tile_type.dart';
-
-/// Test GridWorld that skips onLoad's Match3Game cast.
-class _TestGridWorld extends GridWorld {
-  @override
-  Future<void> onLoad() async {}
-}
-
-const _epsilon = 0.5;
+import 'test_helpers.dart';
 
 void main() {
   group('GridWorld refill placement', () {
     testWithGame<FlameGame>(
       'after refillAll on empty grid, every cell position matches tilePositionAt',
-      () => FlameGame(world: _TestGridWorld()),
+      () => FlameGame(world: TestGridWorld()),
       (game) async {
-        final world = game.world as _TestGridWorld;
+        final world = game.world as TestGridWorld;
         world.grid = List.generate(
             GridWorld.cols, (_) => List.generate(GridWorld.rows, (_) => null));
         // refillAll fills all null cells with random tiles
@@ -36,10 +29,10 @@ void main() {
         for (int x = 0; x < GridWorld.cols; x++) {
           for (int y = 0; y < GridWorld.rows; y++) {
             final pos = world.tilePositionAt(x, y);
-            // Position should be within game bounds
+            // Position should be within game bounds and below the header
             expect(pos.x, greaterThanOrEqualTo(0));
             expect(pos.x, lessThan(gameSize.x));
-            expect(pos.y, greaterThanOrEqualTo(60.0));
+            expect(pos.y, greaterThanOrEqualTo(GridWorld.headerHeight));
             expect(pos.y, lessThan(gameSize.y));
           }
         }
@@ -48,9 +41,9 @@ void main() {
 
     testWithGame<FlameGame>(
       'after partial clear and refillAll, refilled cells at correct positions',
-      () => FlameGame(world: _TestGridWorld()),
+      () => FlameGame(world: TestGridWorld()),
       (game) async {
-        final world = game.world as _TestGridWorld;
+        final world = game.world as TestGridWorld;
         // Start with a full grid
         world.grid = List.generate(GridWorld.cols,
             (_) => List.generate(GridWorld.rows, (_) => TileType.red));
@@ -72,16 +65,16 @@ void main() {
         for (int y = 0; y < 3; y++) {
           final pos = world.tilePositionAt(0, y);
           final origin = world.tilePositionAt(0, 0);
-          expect(pos.y - origin.y, closeTo(y * world.tileSize, _epsilon));
+          expect(pos.y - origin.y, closeTo(y * world.tileSize, kTestEpsilon));
         }
       },
     );
 
     testWithGame<FlameGame>(
       'tilePositionAt(x, -1) is above tilePositionAt(x, 0) — refill animation source',
-      () => FlameGame(world: _TestGridWorld()),
+      () => FlameGame(world: TestGridWorld()),
       (game) async {
-        final world = game.world as _TestGridWorld;
+        final world = game.world as TestGridWorld;
         world.grid = List.generate(
             GridWorld.cols, (_) => List.generate(GridWorld.rows, (_) => null));
         final gameSize = Vector2(400, 800);
@@ -93,17 +86,17 @@ void main() {
         expect(aboveRow0.y, lessThan(row0.y),
             reason: 'Animation source (y=-1) must be above the top row (y=0)');
         // The difference should be exactly one tileSize
-        expect(row0.y - aboveRow0.y, closeTo(world.tileSize, _epsilon));
+        expect(row0.y - aboveRow0.y, closeTo(world.tileSize, kTestEpsilon));
         // Same x coordinate
-        expect(aboveRow0.x, closeTo(row0.x, _epsilon));
+        expect(aboveRow0.x, closeTo(row0.x, kTestEpsilon));
       },
     );
 
     testWithGame<FlameGame>(
       'refill tiles for all target rows spawn above the board top regardless of target row',
-      () => FlameGame(world: _TestGridWorld()),
+      () => FlameGame(world: TestGridWorld()),
       (game) async {
-        final world = game.world as _TestGridWorld;
+        final world = game.world as TestGridWorld;
         world.grid = List.generate(
             GridWorld.cols, (_) => List.generate(GridWorld.rows, (_) => null));
         final gameSize = Vector2(400, 800);
@@ -124,8 +117,8 @@ void main() {
     );
 
     test('refill animation worst-case duration is under cascade await threshold', () {
-      // Cascade await in _runCascade is 300 ms.
-      // Duration for the deepest row (y = rows - 1): 0.035 * rows seconds.
+      // Source: grid_world.dart _refillAllWithAnimation EffectController(duration: 0.035 * (y + 1))
+      // Source: grid_world.dart _runCascade await Future.delayed(const Duration(milliseconds: 300))
       const cascadeAwaitSeconds = 0.300;
       final worstCase = 0.035 * GridWorld.rows;
       expect(worstCase, lessThan(cascadeAwaitSeconds),

--- a/test/game/flame_tile_positions_test.dart
+++ b/test/game/flame_tile_positions_test.dart
@@ -3,61 +3,52 @@ import 'package:flame_test/flame_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:cosmic_match/game/world/grid_world.dart';
 import 'package:cosmic_match/models/tile_type.dart';
-
-/// Test GridWorld that skips onLoad's Match3Game cast.
-class _TestGridWorld extends GridWorld {
-  @override
-  Future<void> onLoad() async {
-    // Skip Match3Game-dependent initialization.
-  }
-}
-
-const _epsilon = 0.5;
+import 'test_helpers.dart';
 
 void main() {
   group('GridWorld tile positions', () {
     testWithGame<FlameGame>(
       'corner tile (0,0) position matches tilePositionAt',
-      () => FlameGame(world: _TestGridWorld()),
+      () => FlameGame(world: TestGridWorld()),
       (game) async {
-        final world = game.world as _TestGridWorld;
+        final world = game.world as TestGridWorld;
         world.grid = List.generate(
             GridWorld.cols, (_) => List.generate(GridWorld.rows, (_) => null));
         world.grid[0][0] = TileType.red;
         final gameSize = Vector2(400, 800);
         world.initLayoutForTest(gameSize);
         final expected = world.tilePositionAt(0, 0);
-        // Verify tileSize is min(width/cols, (height-60)/rows) — width-constrained here
-        expect(world.tileSize, closeTo(gameSize.x / GridWorld.cols, _epsilon));
-        // Verify position is within the board area (below the 60px header)
-        expect(expected.y, greaterThanOrEqualTo(60.0));
+        // Verify tileSize is min(width/cols, (height-headerHeight)/rows) — width-constrained here
+        expect(world.tileSize, closeTo(gameSize.x / GridWorld.cols, kTestEpsilon));
+        // Verify position is within the board area (below the header)
+        expect(expected.y, greaterThanOrEqualTo(GridWorld.headerHeight));
       },
     );
 
     testWithGame<FlameGame>(
       'tileSize uses min(width/cols, height/rows) — height-constrained on square canvas',
-      () => FlameGame(world: _TestGridWorld()),
+      () => FlameGame(world: TestGridWorld()),
       (game) async {
-        final world = game.world as _TestGridWorld;
+        final world = game.world as TestGridWorld;
         world.grid = List.generate(
             GridWorld.cols, (_) => List.generate(GridWorld.rows, (_) => null));
-        // Square canvas: width/cols = 400/8 = 50; (height-60)/rows = (400-60)/8 = 42.5
+        // Square canvas: width/cols = 400/8 = 50; (height-headerHeight)/rows = (400-60)/8 = 42.5
         // min() picks 42.5 (height-constrained); a width-only formula would pick 50.
         final gameSize = Vector2(400, 400);
         world.initLayoutForTest(gameSize);
-        const expectedTileSize = (400.0 - 60.0) / GridWorld.rows;
-        expect(world.tileSize, closeTo(expectedTileSize, _epsilon));
+        const expectedTileSize = (400.0 - GridWorld.headerHeight) / GridWorld.rows;
+        expect(world.tileSize, closeTo(expectedTileSize, kTestEpsilon));
         // Verify the grid stays on screen: boardOffset.y + rows * tileSize <= height
         final bottomEdge = world.tilePositionAt(0, GridWorld.rows - 1).y + world.tileSize;
-        expect(bottomEdge, lessThanOrEqualTo(gameSize.y + _epsilon));
+        expect(bottomEdge, lessThanOrEqualTo(gameSize.y + kTestEpsilon));
       },
     );
 
     testWithGame<FlameGame>(
       'far corner tile (7,7) position matches tilePositionAt',
-      () => FlameGame(world: _TestGridWorld()),
+      () => FlameGame(world: TestGridWorld()),
       (game) async {
-        final world = game.world as _TestGridWorld;
+        final world = game.world as TestGridWorld;
         world.grid = List.generate(
             GridWorld.cols, (_) => List.generate(GridWorld.rows, (_) => null));
         world.grid[7][7] = TileType.blue;
@@ -66,16 +57,16 @@ void main() {
         final expected = world.tilePositionAt(7, 7);
         final origin = world.tilePositionAt(0, 0);
         // (7,7) should be 7*tileSize away from (0,0) in both axes
-        expect(expected.x - origin.x, closeTo(7 * world.tileSize, _epsilon));
-        expect(expected.y - origin.y, closeTo(7 * world.tileSize, _epsilon));
+        expect(expected.x - origin.x, closeTo(7 * world.tileSize, kTestEpsilon));
+        expect(expected.y - origin.y, closeTo(7 * world.tileSize, kTestEpsilon));
       },
     );
 
     testWithGame<FlameGame>(
       'adjacent tiles are exactly tileSize apart horizontally',
-      () => FlameGame(world: _TestGridWorld()),
+      () => FlameGame(world: TestGridWorld()),
       (game) async {
-        final world = game.world as _TestGridWorld;
+        final world = game.world as TestGridWorld;
         world.grid = List.generate(
             GridWorld.cols, (_) => List.generate(GridWorld.rows, (_) => null));
         world.grid[2][3] = TileType.yellow;
@@ -84,16 +75,16 @@ void main() {
         world.initLayoutForTest(gameSize);
         final posA = world.tilePositionAt(2, 3);
         final posB = world.tilePositionAt(3, 3);
-        expect(posB.x - posA.x, closeTo(world.tileSize, _epsilon));
-        expect(posA.y, closeTo(posB.y, _epsilon)); // same row
+        expect(posB.x - posA.x, closeTo(world.tileSize, kTestEpsilon));
+        expect(posA.y, closeTo(posB.y, kTestEpsilon)); // same row
       },
     );
 
     testWithGame<FlameGame>(
       'adjacent tiles are exactly tileSize apart vertically',
-      () => FlameGame(world: _TestGridWorld()),
+      () => FlameGame(world: TestGridWorld()),
       (game) async {
-        final world = game.world as _TestGridWorld;
+        final world = game.world as TestGridWorld;
         world.grid = List.generate(
             GridWorld.cols, (_) => List.generate(GridWorld.rows, (_) => null));
         world.grid[4][1] = TileType.purple;
@@ -102,8 +93,8 @@ void main() {
         world.initLayoutForTest(gameSize);
         final posA = world.tilePositionAt(4, 1);
         final posB = world.tilePositionAt(4, 2);
-        expect(posB.y - posA.y, closeTo(world.tileSize, _epsilon));
-        expect(posA.x, closeTo(posB.x, _epsilon)); // same column
+        expect(posB.y - posA.y, closeTo(world.tileSize, kTestEpsilon));
+        expect(posA.x, closeTo(posB.x, kTestEpsilon)); // same column
       },
     );
   });

--- a/test/game/test_helpers.dart
+++ b/test/game/test_helpers.dart
@@ -19,12 +19,8 @@ class TestGridWorld extends GridWorld {
   @override
   Future<void> onLoad() async {
     // Intentionally empty — skip Match3Game cast and all engine-dependent setup.
-    // Call initLayoutForTest(gameSize) to configure layout after construction.
   }
 }
 
 /// Tolerance for floating-point position comparisons (half a pixel).
-///
-/// Used in `closeTo(value, kTestEpsilon)` matchers where sub-pixel differences
-/// in floating-point arithmetic are acceptable.
 const double kTestEpsilon = 0.5;

--- a/test/game/test_helpers.dart
+++ b/test/game/test_helpers.dart
@@ -1,0 +1,30 @@
+import 'package:cosmic_match/game/world/grid_world.dart';
+
+/// Test double for [GridWorld] that skips [GridWorld.onLoad]'s [Match3Game]
+/// cast so that geometry tests can run headlessly without a full game engine.
+///
+/// Usage:
+/// ```dart
+/// testWithGame<FlameGame>(
+///   'my test',
+///   () => FlameGame(world: TestGridWorld()),
+///   (game) async {
+///     final world = game.world as TestGridWorld;
+///     world.initLayoutForTest(Vector2(400, 800));
+///     ...
+///   },
+/// );
+/// ```
+class TestGridWorld extends GridWorld {
+  @override
+  Future<void> onLoad() async {
+    // Intentionally empty — skip Match3Game cast and all engine-dependent setup.
+    // Call initLayoutForTest(gameSize) to configure layout after construction.
+  }
+}
+
+/// Tolerance for floating-point position comparisons (half a pixel).
+///
+/// Used in `closeTo(value, kTestEpsilon)` matchers where sub-pixel differences
+/// in floating-point arithmetic are acceptable.
+const double kTestEpsilon = 0.5;


### PR DESCRIPTION
## Summary

- Extracts `TestGridWorld` and `kTestEpsilon` into a shared `test/game/test_helpers.dart`, eliminating verbatim duplication across 3 flame_test files
- Adds `GridWorld.headerHeight = 60.0` static constant, replacing magic `60` literals in both `_applyLayout` and test assertions
- Adds source-citing comments to the refill duration timing test
- Expands the debug-mode comment in `flame_cascade_fsm_test` to explain assert-vs-reset behaviour

Addresses review findings from the flame_test coverage PR (issue #42).

## Validation

| Check | Result |
|-------|--------|
| `flutter analyze` | ✅ 0 issues |
| `flutter test` | ✅ 209 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)