### PR TITLE
fix: address code-review findings for issue #42 (LOW-severity style items)

### DIFF
--- a/test/game/flame_refill_placement_test.dart
+++ b/test/game/flame_refill_placement_test.dart
@@ -34,13 +34,12 @@ void main() {
             expect(pos.x, lessThan(gameSize.x));
             expect(pos.y, greaterThanOrEqualTo(GridWorld.headerHeight));
             expect(pos.y, lessThan(gameSize.y));
-            // For the last row, verify the tile's bottom edge also fits on screen.
-            if (y == GridWorld.rows - 1) {
-              expect(pos.y + world.tileSize, lessThanOrEqualTo(gameSize.y + kTestEpsilon),
-                  reason: 'Bottom edge of last row must not overflow the viewport');
-            }
           }
         }
+        // Verify the bottom edge of the last row doesn't overflow the viewport.
+        final lastRowBottom = world.tilePositionAt(0, GridWorld.rows - 1).y + world.tileSize;
+        expect(lastRowBottom, lessThanOrEqualTo(gameSize.y + kTestEpsilon),
+            reason: 'Bottom edge of last row must not overflow the viewport');
       },
     );
 

--- a/test/game/flame_refill_placement_test.dart
+++ b/test/game/flame_refill_placement_test.dart
@@ -34,6 +34,11 @@ void main() {
             expect(pos.x, lessThan(gameSize.x));
             expect(pos.y, greaterThanOrEqualTo(GridWorld.headerHeight));
             expect(pos.y, lessThan(gameSize.y));
+            // For the last row, verify the tile's bottom edge also fits on screen.
+            if (y == GridWorld.rows - 1) {
+              expect(pos.y + world.tileSize, lessThanOrEqualTo(gameSize.y + kTestEpsilon),
+                  reason: 'Bottom edge of last row must not overflow the viewport');
+            }
           }
         }
       },

--- a/test/game/flame_tile_positions_test.dart
+++ b/test/game/flame_tile_positions_test.dart
@@ -26,13 +26,13 @@ void main() {
     );
 
     testWithGame<FlameGame>(
-      'tileSize uses min(width/cols, height/rows) — height-constrained on square canvas',
+      'tileSize uses min(width/cols, (height−headerHeight)/rows) — height-constrained on square canvas',
       () => FlameGame(world: TestGridWorld()),
       (game) async {
         final world = game.world as TestGridWorld;
         world.grid = List.generate(
             GridWorld.cols, (_) => List.generate(GridWorld.rows, (_) => null));
-        // Square canvas: width/cols = 400/8 = 50; (height-headerHeight)/rows = (400-60)/8 = 42.5
+        // Square canvas: width/cols = 400/8 = 50; (height-headerHeight)/rows = (400-GridWorld.headerHeight)/8 = 42.5
         // min() picks 42.5 (height-constrained); a width-only formula would pick 50.
         final gameSize = Vector2(400, 400);
         world.initLayoutForTest(gameSize);


### PR DESCRIPTION
## Summary

Addresses 3 LOW-severity findings from the code review of the issue #42 implementation (PRs #86, #91, #92).

- Fix stale magic number `60` in inline comment — replaced with `GridWorld.headerHeight` to avoid drift if the constant changes
- Correct test description string to accurately reflect the formula `(height−headerHeight)/rows` instead of `height/rows`
- Add bottom-edge overflow assertion for the last row in `flame_refill_placement_test.dart` to catch future regressions

## Test plan

- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — 213 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)