### PR TITLE
feat: wire sentry_dart_plugin for debug symbol upload + launch smoke-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,13 +125,30 @@ jobs:
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           FEEDBACK_WORKER_URL: ${{ vars.FEEDBACK_WORKER_URL || 'https://feedback.alexsiri7.workers.dev/' }}
-        run: flutter build appbundle --release --dart-define=SENTRY_DSN=$SENTRY_DSN --dart-define=FEEDBACK_WORKER_URL=$FEEDBACK_WORKER_URL
+        # --split-debug-info + --obfuscate produce the Dart debug symbols that
+        # sentry_dart_plugin uploads in the next step, enabling server-side
+        # symbolication of release stack traces.
+        run: flutter build appbundle --release --split-debug-info=build/symbols --obfuscate --dart-define=SENTRY_DSN=$SENTRY_DSN --dart-define=FEEDBACK_WORKER_URL=$FEEDBACK_WORKER_URL
+
+      - name: Upload debug symbols to Sentry (AAB)
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        # Gate on SENTRY_AUTH_TOKEN so PRs from forks (no secret access)
+        # don't fail this step.
+        if: env.SENTRY_AUTH_TOKEN != ''
+        run: flutter pub run sentry_dart_plugin
 
       - name: Build release APK
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           FEEDBACK_WORKER_URL: ${{ vars.FEEDBACK_WORKER_URL || 'https://feedback.alexsiri7.workers.dev/' }}
-        run: flutter build apk --release --dart-define=SENTRY_DSN=$SENTRY_DSN --dart-define=FEEDBACK_WORKER_URL=$FEEDBACK_WORKER_URL
+        run: flutter build apk --release --split-debug-info=build/symbols --obfuscate --dart-define=SENTRY_DSN=$SENTRY_DSN --dart-define=FEEDBACK_WORKER_URL=$FEEDBACK_WORKER_URL
+
+      - name: Upload debug symbols to Sentry (APK)
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        if: env.SENTRY_AUTH_TOKEN != ''
+        run: flutter pub run sentry_dart_plugin
 
       - name: Upload signed AAB
         if: steps.keystore.outputs.used_real == 'yes'

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:ui' as ui;
 import 'package:flutter/foundation.dart';
@@ -15,6 +16,7 @@ import 'screens/home_screen.dart';
 import 'services/feedback_service.dart';
 import 'services/key_service.dart';
 import 'services/progress_service.dart';
+import 'services/sentry_smoke_service.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -67,6 +69,13 @@ Future<void> main() async {
       },
       appRunner: launch,
     );
+    // Fire a one-shot launch-smoke message so we can confirm — per install
+    // per buildNumber — that the release launched and symbolication is wired.
+    // Runs after init so the event actually has a DSN to ship to.
+    unawaited(SentrySmokeService().maybeFire(
+      version: packageInfo.version,
+      buildNumber: packageInfo.buildNumber,
+    ));
   } catch (e, stack) {
     // Sentry init failure must not prevent the app from launching.
     gameLogger.w('Sentry init failed — crash reporting disabled', error: e, stackTrace: stack);

--- a/lib/services/sentry_smoke_service.dart
+++ b/lib/services/sentry_smoke_service.dart
@@ -1,0 +1,66 @@
+import 'package:hive/hive.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+import '../core/logger.dart';
+
+/// Fires a one-shot Sentry "launch-smoke" message per install per buildNumber.
+///
+/// Purpose: after a new release rolls out, we want a single breadcrumb in
+/// Sentry confirming the build was actually launched on a device and that
+/// its debug-symbol upload / symbolication path is wired correctly.
+///
+/// The message fires exactly once per (install, buildNumber) pair. The last
+/// buildNumber observed is persisted in a small Hive box so reinstalls also
+/// re-fire the smoke test (a fresh install is a legitimate "did this build
+/// actually launch" signal), while everyday cold starts do not spam Sentry.
+class SentrySmokeService {
+  static const _boxName = 'sentry_smoke';
+  static const _key = 'last_smoke_build_number';
+
+  /// Callable that sends the smoke message. Defaults to [Sentry.captureMessage]
+  /// but is overridable in tests.
+  final Future<void> Function(String message) _send;
+
+  /// Opens the Hive box. Overridable in tests.
+  final Future<Box<dynamic>> Function(String name) _openBox;
+
+  SentrySmokeService({
+    Future<void> Function(String message)? send,
+    Future<Box<dynamic>> Function(String name)? openBox,
+  })  : _send = send ?? _defaultSend,
+        _openBox = openBox ?? _defaultOpenBox;
+
+  static Future<void> _defaultSend(String message) async {
+    await Sentry.captureMessage(message);
+  }
+
+  static Future<Box<dynamic>> _defaultOpenBox(String name) =>
+      Hive.openBox<dynamic>(name);
+
+  /// Fires a smoke message iff [buildNumber] differs from the last observed
+  /// one. Returns `true` when a message was actually sent.
+  ///
+  /// Failures (Hive or Sentry) are swallowed and logged — a smoke test must
+  /// never crash the app.
+  Future<bool> maybeFire({
+    required String version,
+    required String buildNumber,
+  }) async {
+    try {
+      final box = await _openBox(_boxName);
+      final last = box.get(_key);
+      if (last == buildNumber) {
+        gameLogger.d(
+            'SentrySmokeService: skipping, buildNumber=$buildNumber already smoke-tested');
+        return false;
+      }
+      await _send('launch-smoke v$version+$buildNumber');
+      await box.put(_key, buildNumber);
+      gameLogger.i('SentrySmokeService: fired for $version+$buildNumber');
+      return true;
+    } catch (e, stack) {
+      gameLogger.w('SentrySmokeService.maybeFire failed',
+          error: e, stackTrace: stack);
+      return false;
+    }
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,6 +17,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "10.0.1"
+  ansicolor:
+    dependency: transitive
+    description:
+      name: ansicolor
+      sha256: "50e982d500bc863e1d703448afdbf9e5a72eb48840a4f766fa361ffd6877055f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.3"
   archive:
     dependency: "direct main"
     description:
@@ -298,6 +306,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  globbing:
+    dependency: transitive
+    description:
+      name: globbing
+      sha256: "4f89cfaf6fa74c9c1740a96259da06bd45411ede56744e28017cc534a12b6e2d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   google_fonts:
     dependency: "direct main"
     description:
@@ -354,6 +370,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  injector:
+    dependency: transitive
+    description:
+      name: injector
+      sha256: ed389bed5b48a699d5b9561c985023d0d5cc88dd5ff2237aadcce5a5ab433e4e
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   integration_test:
     dependency: "direct dev"
     description: flutter
@@ -631,6 +655,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.5"
+  properties:
+    dependency: transitive
+    description:
+      name: properties
+      sha256: "333f427dd4ed07bdbe8c75b9ff864a1e70b5d7a8426a2e8bdd457b65ae5ac598"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   pub_semver:
     dependency: transitive
     description:
@@ -655,6 +687,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.14.2"
+  sentry_dart_plugin:
+    dependency: "direct dev"
+    description:
+      name: sentry_dart_plugin
+      sha256: "84436958fa9231e2e716be117a3b31695e54458b9f27039f76d14515e24248a6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sentry_flutter:
     dependency: "direct main"
     description:
@@ -764,6 +804,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.1"
+  system_info2:
+    dependency: transitive
+    description:
+      name: system_info2
+      sha256: b937736ecfa63c45b10dde1ceb6bb30e5c0c340e14c441df024150679d65ac43
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,8 +31,25 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^6.0.0
   flame_test: ^2.2.4
+  sentry_dart_plugin: ^2.0.0
 
 flutter:
   uses-material-design: true
   assets:
     - assets/images/
+
+# sentry_dart_plugin configuration.
+# Runs via `flutter pub run sentry_dart_plugin` after release builds in CI
+# to upload Dart debug symbols / obfuscation maps to Sentry so stack traces
+# can be symbolicated server-side.
+#
+# auth_token is NOT stored here — it's read from the SENTRY_AUTH_TOKEN env
+# var supplied by the CI job. The EU region still uses the sentry.io base
+# URL; the plugin auto-routes based on org.
+sentry:
+  upload_debug_symbols: true
+  upload_source_maps: true
+  upload_sources: true
+  project: cosmic-match
+  org: alex-siri
+  url: https://sentry.io/

--- a/test/services/sentry_smoke_service_test.dart
+++ b/test/services/sentry_smoke_service_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:cosmic_match/services/sentry_smoke_service.dart';
+
+/// Minimal in-memory stand-in for a Hive box. Only the subset of the API
+/// used by [SentrySmokeService] is implemented.
+class _FakeBox implements Box<dynamic> {
+  final Map<dynamic, dynamic> _store = {};
+
+  @override
+  dynamic get(dynamic key, {dynamic defaultValue}) =>
+      _store.containsKey(key) ? _store[key] : defaultValue;
+
+  @override
+  Future<void> put(dynamic key, dynamic value) async {
+    _store[key] = value;
+  }
+
+  // Unused members — throwing signals a test-only drift if anything starts
+  // calling them.
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  group('SentrySmokeService.maybeFire', () {
+    late _FakeBox box;
+    late List<String> sent;
+    late SentrySmokeService service;
+
+    setUp(() {
+      box = _FakeBox();
+      sent = [];
+      service = SentrySmokeService(
+        send: (msg) async => sent.add(msg),
+        openBox: (_) async => box,
+      );
+    });
+
+    test('fires on first call and persists buildNumber', () async {
+      final fired = await service.maybeFire(version: '1.0.0', buildNumber: '1');
+      expect(fired, isTrue);
+      expect(sent, ['launch-smoke v1.0.0+1']);
+      expect(box.get('last_smoke_build_number'), '1');
+    });
+
+    test('does not fire again for the same buildNumber', () async {
+      await service.maybeFire(version: '1.0.0', buildNumber: '1');
+      final firedAgain =
+          await service.maybeFire(version: '1.0.0', buildNumber: '1');
+      expect(firedAgain, isFalse);
+      expect(sent, ['launch-smoke v1.0.0+1']);
+    });
+
+    test('fires again when buildNumber changes', () async {
+      await service.maybeFire(version: '1.0.0', buildNumber: '1');
+      final fired =
+          await service.maybeFire(version: '1.0.1', buildNumber: '2');
+      expect(fired, isTrue);
+      expect(sent, ['launch-smoke v1.0.0+1', 'launch-smoke v1.0.1+2']);
+      expect(box.get('last_smoke_build_number'), '2');
+    });
+
+    test('swallows send failures and reports not-fired', () async {
+      final throwing = SentrySmokeService(
+        send: (_) async => throw StateError('sentry unavailable'),
+        openBox: (_) async => box,
+      );
+      final fired =
+          await throwing.maybeFire(version: '1.0.0', buildNumber: '1');
+      expect(fired, isFalse);
+      // Nothing persisted, so a later successful call can still fire.
+      expect(box.get('last_smoke_build_number'), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add `sentry_dart_plugin ^2.0.0` (dev dep; resolves to 2.4.1, the latest 2.x line compatible with `sentry_flutter ^8.12.0`) and a top-level `sentry:` config block in `pubspec.yaml`. No secrets committed — the plugin reads `SENTRY_AUTH_TOKEN` from the environment.
- CI builds release AAB/APK with `--split-debug-info=build/symbols --obfuscate`, then runs `flutter pub run sentry_dart_plugin` to upload the Dart debug info / obfuscation maps to Sentry for server-side symbolication. The upload steps are gated on `env.SENTRY_AUTH_TOKEN != ''` so fork PRs (no secret access) still pass.
- New `SentrySmokeService` fires `Sentry.captureMessage("launch-smoke v<version>+<buildNumber>")` exactly once per install per buildNumber, persisted in a small Hive box. Called from `main.dart` after `SentryFlutter.init` completes. Failures are swallowed — a smoke test must never crash the app.
- Unit tests cover: first-fire, suppressed-on-same-build, re-fires-on-new-build, and swallow-send-failure.

## Test plan
- [x] `flutter pub get` resolves (`sentry_dart_plugin 2.4.1` picked, compatible with `sentry_flutter 8.14.2`).
- [x] `flutter analyze` — clean.
- [x] `flutter test` — all 217 tests pass, including the 4 new `sentry_smoke_service_test` cases.
- [ ] CI green on this PR.
- [ ] After merge: new `release-apk` artifact on main includes the new commit SHA, and a `launch-smoke v1.0.0+1` event shows up in Sentry on first device launch.

Refs: `alex-siri` org / `cosmic-match` project on Sentry (EU region — still uses `https://sentry.io/` as the CLI base URL; the plugin auto-routes based on org).