### PR TITLE
fix: use arm64-v8a emulator arch for Apple Silicon CI runner

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,5 +35,5 @@ jobs:
         with:
           api-level: 34
           target: google_apis
-          arch: x86_64
+          arch: arm64-v8a
           script: flutter test integration_test/


### PR DESCRIPTION
## Summary

Fix the failing Integration Tests CI job on `macos-14` runners by correcting the Android emulator architecture specification.

## Problem

The Integration Tests job on the main CI workflow fails immediately after emulator launch with a FATAL error:
```
FATAL | Avd's CPU Architecture 'x86_64' is not supported by the QEMU2 emulator on aarch64 host. System image must match the host architecture.
```

**Root Cause**: The workflow was configured for `x86_64` system image, but `macos-14` GitHub-hosted runners use Apple Silicon (ARM64), so QEMU2 cannot emulate a different architecture than the host.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/integration.yml` | Line 38: `arch: x86_64` → `arch: arm64-v8a` |

The `arm64-v8a` system image runs natively on Apple Silicon hosts, eliminating the architecture mismatch.

## Validation

| Check | Result | Details |
|-------|--------|---------|
| Flutter analyze | ✅ Pass | No issues found |
| Flutter test | ✅ Pass | 218 tests passed, 0 failed |
| Code review | ✅ Pass | Scope limited to workflow configuration only |

**Note**: Build validation blocked by Java 25 incompatibility with Kotlin compiler (pre-existing environment issue, unrelated to this change).

## References

- **Issue**: Fixes #101
- **Root cause**: `macos-14` runners are aarch64; workflow specified `x86_64` architecture
- **Impact**: Unblocks all CI-gated merges to main branch