### PR TITLE
fix: switch integration CI to ubuntu-latest + x86_64 + KVM

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,6 +3,8 @@ name: Integration
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -11,7 +13,7 @@ permissions:
 jobs:
   integration:
     name: Integration Tests
-    runs-on: macos-14
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -28,6 +30,12 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4.4.1
 
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - run: flutter pub get
 
       - name: Run integration tests on Android emulator
@@ -35,5 +43,5 @@ jobs:
         with:
           api-level: 34
           target: google_apis
-          arch: arm64-v8a
+          arch: x86_64
           script: flutter test integration_test/


### PR DESCRIPTION
## Root cause

The integration workflow has been failing on **every** run since it was first added in #91 — including after #102 switched the arch to `arm64-v8a`.

Both configurations share the same underlying problem: **`macos-14` runners (Apple Silicon) don't support nested virtualisation**, so the Android emulator can never acquire HVF and always times out waiting to boot.

Per the `ReactiveCircus/android-emulator-runner` maintainer ([issue #453](https://github.com/ReactiveCircus/android-emulator-runner/issues/453)):
> "There is literally no way to do an arm64 emulator in github actions on hosted runners — mac hosted runners do not support nested virtualization."

## Fix

Switch to the standard, well-tested path: `ubuntu-latest` + `arch: x86_64` + KVM acceleration.

GitHub's Linux runners support KVM, which lets the x86_64 Android emulator boot in seconds rather than timing out.

**Changes:**
- `runs-on: macos-14` → `ubuntu-latest`
- `arch: arm64-v8a` → `x86_64`
- Add "Enable KVM" step (udev rule granting `kvm` group access — required before the emulator action starts)
- Add `pull_request:` trigger so this PR self-validates before merging

## Verification

This PR adds a `pull_request` trigger, so the Integration Tests job will run on this PR. A green check here confirms the fix works end-to-end.

Fixes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)