### PR TITLE
fix: handle connectivity stream errors and network exceptions in feedback (#112)

### DIFF
--- a/lib/services/feedback_service.dart
+++ b/lib/services/feedback_service.dart
@@ -22,11 +22,16 @@ class FeedbackService {
 
   /// Start listening for connectivity changes to flush queued feedback.
   void listenConnectivity() {
-    _connectivitySub = Connectivity().onConnectivityChanged.listen((results) {
-      if (!results.contains(ConnectivityResult.none)) {
-        flushQueue();
-      }
-    });
+    _connectivitySub = Connectivity().onConnectivityChanged.listen(
+      (results) {
+        if (!results.contains(ConnectivityResult.none)) {
+          flushQueue();
+        }
+      },
+      onError: (Object e, StackTrace s) {
+        gameLogger.w('FeedbackService: connectivity stream error', error: e, stackTrace: s);
+      },
+    );
   }
 
   /// Cancel connectivity listener.

--- a/lib/services/github_feedback_client.dart
+++ b/lib/services/github_feedback_client.dart
@@ -45,15 +45,23 @@ class GitHubFeedbackClient {
     final b64 = base64Encode(pngBytes);
     final uri = Uri.parse(
         'https://api.github.com/repos/$_repo/contents/docs/feedback/$id.png');
-    final response = await _client.put(
-      uri,
-      headers: _headers,
-      body: jsonEncode({
-        'message': 'feedback image $id',
-        'content': b64,
-        'branch': 'main',
-      }),
-    );
+
+    final http.Response response;
+    try {
+      response = await _client
+          .put(
+            uri,
+            headers: _headers,
+            body: jsonEncode({
+              'message': 'feedback image $id',
+              'content': b64,
+              'branch': 'main',
+            }),
+          )
+          .timeout(const Duration(seconds: 15));
+    } catch (e) {
+      throw FeedbackClientException('Image upload network error: $e');
+    }
 
     if (response.statusCode < 200 || response.statusCode >= 300) {
       final snippet = response.body.substring(0, response.body.length.clamp(0, 200));
@@ -76,15 +84,23 @@ class GitHubFeedbackClient {
     gameLogger.d('GitHubFeedbackClient.createIssue');
 
     final uri = Uri.parse('https://api.github.com/repos/$_repo/issues');
-    final response = await _client.post(
-      uri,
-      headers: _headers,
-      body: jsonEncode({
-        'title': 'In-app feedback',
-        'body': '$description\n\n![]($imageUrl)',
-        'labels': ['feedback'],
-      }),
-    );
+
+    final http.Response response;
+    try {
+      response = await _client
+          .post(
+            uri,
+            headers: _headers,
+            body: jsonEncode({
+              'title': 'In-app feedback',
+              'body': '$description\n\n![]($imageUrl)',
+              'labels': ['feedback'],
+            }),
+          )
+          .timeout(const Duration(seconds: 15));
+    } catch (e) {
+      throw FeedbackClientException('Issue creation network error: $e');
+    }
 
     if (response.statusCode < 200 || response.statusCode >= 300) {
       final snippet = response.body.substring(0, response.body.length.clamp(0, 200));

--- a/lib/services/github_feedback_client.dart
+++ b/lib/services/github_feedback_client.dart
@@ -64,13 +64,7 @@ class GitHubFeedbackClient {
       throw FeedbackClientException('Image upload network error: $e');
     }
 
-    if (response.statusCode < 200 || response.statusCode >= 300) {
-      final snippet = response.body.substring(0, response.body.length.clamp(0, 200));
-      gameLogger.e(
-          'GitHubFeedbackClient.uploadImage failed: ${response.statusCode} — $snippet');
-      throw FeedbackClientException(
-          'Image upload failed with status ${response.statusCode}');
-    }
+    _throwIfError(response, method: 'uploadImage', label: 'Image upload');
 
     final json = jsonDecode(response.body) as Map<String, dynamic>;
     final content = json['content'] as Map<String, dynamic>;
@@ -104,15 +98,24 @@ class GitHubFeedbackClient {
       throw FeedbackClientException('Issue creation network error: $e');
     }
 
-    if (response.statusCode < 200 || response.statusCode >= 300) {
-      final snippet = response.body.substring(0, response.body.length.clamp(0, 200));
-      gameLogger.e(
-          'GitHubFeedbackClient.createIssue failed: ${response.statusCode} — $snippet');
-      throw FeedbackClientException(
-          'Issue creation failed with status ${response.statusCode}');
-    }
+    _throwIfError(response, method: 'createIssue', label: 'Issue creation');
 
     final json = jsonDecode(response.body) as Map<String, dynamic>;
     return json['html_url'] as String;
+  }
+
+  void _throwIfError(
+    http.Response response, {
+    required String method,
+    required String label,
+  }) {
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      final snippet =
+          response.body.substring(0, response.body.length.clamp(0, 200));
+      gameLogger.e(
+          'GitHubFeedbackClient.$method failed: ${response.statusCode} — $snippet');
+      throw FeedbackClientException(
+          '$label failed with status ${response.statusCode}');
+    }
   }
 }

--- a/lib/services/github_feedback_client.dart
+++ b/lib/services/github_feedback_client.dart
@@ -59,7 +59,8 @@ class GitHubFeedbackClient {
             }),
           )
           .timeout(const Duration(seconds: 15));
-    } catch (e) {
+    } catch (e, stack) {
+      gameLogger.w('GitHubFeedbackClient.uploadImage: network error', error: e, stackTrace: stack);
       throw FeedbackClientException('Image upload network error: $e');
     }
 
@@ -98,7 +99,8 @@ class GitHubFeedbackClient {
             }),
           )
           .timeout(const Duration(seconds: 15));
-    } catch (e) {
+    } catch (e, stack) {
+      gameLogger.w('GitHubFeedbackClient.createIssue: network error', error: e, stackTrace: stack);
       throw FeedbackClientException('Issue creation network error: $e');
     }
 

--- a/test/game/flame_gravity_sync_test.dart
+++ b/test/game/flame_gravity_sync_test.dart
@@ -13,8 +13,7 @@ void main() {
       () => FlameGame(world: TestGridWorld()),
       (game) async {
         final world = game.world as TestGridWorld;
-        world.grid = List.generate(
-            GridWorld.cols, (_) => List.generate(GridWorld.rows, (_) => null));
+        world.grid = createEmptyGrid();
         // Place tile at (0, 5) with null below at (0, 6)
         world.grid[0][5] = TileType.red;
         final gameSize = Vector2(400, 800);
@@ -39,8 +38,7 @@ void main() {
       () => FlameGame(world: TestGridWorld()),
       (game) async {
         final world = game.world as TestGridWorld;
-        world.grid = List.generate(
-            GridWorld.cols, (_) => List.generate(GridWorld.rows, (_) => null));
+        world.grid = createEmptyGrid();
         world.grid[0][0] = TileType.red;
         final gameSize = Vector2(400, 800);
         world.initLayoutForTest(gameSize);
@@ -64,8 +62,7 @@ void main() {
       () => FlameGame(world: TestGridWorld()),
       (game) async {
         final world = game.world as TestGridWorld;
-        world.grid = List.generate(
-            GridWorld.cols, (_) => List.generate(GridWorld.rows, (_) => null));
+        world.grid = createEmptyGrid();
         world.grid[3][0] = TileType.yellow;
         final gameSize = Vector2(400, 800);
 
@@ -87,8 +84,7 @@ void main() {
       () => FlameGame(world: TestGridWorld()),
       (game) async {
         final world = game.world as TestGridWorld;
-        world.grid = List.generate(
-            GridWorld.cols, (_) => List.generate(GridWorld.rows, (_) => null));
+        world.grid = createEmptyGrid();
         // Place 3 tiles in column 2: rows 0, 1, 2
         world.grid[2][0] = TileType.blue;
         world.grid[2][1] = TileType.orange;
@@ -121,8 +117,7 @@ void main() {
       () => FlameGame(world: TestGridWorld()),
       (game) async {
         final world = game.world as TestGridWorld;
-        world.grid = List.generate(
-            GridWorld.cols, (_) => List.generate(GridWorld.rows, (_) => null));
+        world.grid = createEmptyGrid();
         world.grid[0][0] = TileType.red;
         world.initLayoutForTest(Vector2(400, 800));
 

--- a/test/game/flame_refill_placement_test.dart
+++ b/test/game/flame_refill_placement_test.dart
@@ -12,8 +12,7 @@ void main() {
       () => FlameGame(world: TestGridWorld()),
       (game) async {
         final world = game.world as TestGridWorld;
-        world.grid = List.generate(
-            GridWorld.cols, (_) => List.generate(GridWorld.rows, (_) => null));
+        world.grid = createEmptyGrid();
         // refillAll fills all null cells with random tiles
         world.refillAll();
         // Verify every cell is filled
@@ -79,8 +78,7 @@ void main() {
       () => FlameGame(world: TestGridWorld()),
       (game) async {
         final world = game.world as TestGridWorld;
-        world.grid = List.generate(
-            GridWorld.cols, (_) => List.generate(GridWorld.rows, (_) => null));
+        world.grid = createEmptyGrid();
         final gameSize = Vector2(400, 800);
         world.initLayoutForTest(gameSize);
 
@@ -101,8 +99,7 @@ void main() {
       () => FlameGame(world: TestGridWorld()),
       (game) async {
         final world = game.world as TestGridWorld;
-        world.grid = List.generate(
-            GridWorld.cols, (_) => List.generate(GridWorld.rows, (_) => null));
+        world.grid = createEmptyGrid();
         final gameSize = Vector2(400, 800);
         world.initLayoutForTest(gameSize);
 

--- a/test/game/flame_tile_positions_test.dart
+++ b/test/game/flame_tile_positions_test.dart
@@ -12,8 +12,7 @@ void main() {
       () => FlameGame(world: TestGridWorld()),
       (game) async {
         final world = game.world as TestGridWorld;
-        world.grid = List.generate(
-            GridWorld.cols, (_) => List.generate(GridWorld.rows, (_) => null));
+        world.grid = createEmptyGrid();
         world.grid[0][0] = TileType.red;
         final gameSize = Vector2(400, 800);
         world.initLayoutForTest(gameSize);
@@ -30,8 +29,7 @@ void main() {
       () => FlameGame(world: TestGridWorld()),
       (game) async {
         final world = game.world as TestGridWorld;
-        world.grid = List.generate(
-            GridWorld.cols, (_) => List.generate(GridWorld.rows, (_) => null));
+        world.grid = createEmptyGrid();
         // Square canvas: width/cols = 400/8 = 50; (height-headerHeight)/rows = (400-GridWorld.headerHeight)/8 = 42.5
         // min() picks 42.5 (height-constrained); a width-only formula would pick 50.
         final gameSize = Vector2(400, 400);
@@ -49,8 +47,7 @@ void main() {
       () => FlameGame(world: TestGridWorld()),
       (game) async {
         final world = game.world as TestGridWorld;
-        world.grid = List.generate(
-            GridWorld.cols, (_) => List.generate(GridWorld.rows, (_) => null));
+        world.grid = createEmptyGrid();
         world.grid[7][7] = TileType.blue;
         final gameSize = Vector2(400, 800);
         world.initLayoutForTest(gameSize);
@@ -67,8 +64,7 @@ void main() {
       () => FlameGame(world: TestGridWorld()),
       (game) async {
         final world = game.world as TestGridWorld;
-        world.grid = List.generate(
-            GridWorld.cols, (_) => List.generate(GridWorld.rows, (_) => null));
+        world.grid = createEmptyGrid();
         world.grid[2][3] = TileType.yellow;
         world.grid[3][3] = TileType.yellow;
         final gameSize = Vector2(400, 800);
@@ -85,8 +81,7 @@ void main() {
       () => FlameGame(world: TestGridWorld()),
       (game) async {
         final world = game.world as TestGridWorld;
-        world.grid = List.generate(
-            GridWorld.cols, (_) => List.generate(GridWorld.rows, (_) => null));
+        world.grid = createEmptyGrid();
         world.grid[4][1] = TileType.purple;
         world.grid[4][2] = TileType.purple;
         final gameSize = Vector2(400, 800);

--- a/test/game/test_helpers.dart
+++ b/test/game/test_helpers.dart
@@ -1,4 +1,5 @@
 import 'package:cosmic_match/game/world/grid_world.dart';
+import 'package:cosmic_match/models/tile_type.dart';
 
 /// Test double for [GridWorld] that skips [GridWorld.onLoad]'s [Match3Game]
 /// cast so that geometry tests can run headlessly without a full game engine.
@@ -24,3 +25,7 @@ class TestGridWorld extends GridWorld {
 
 /// Tolerance for floating-point position comparisons (half a pixel).
 const double kTestEpsilon = 0.5;
+
+/// Returns an empty (all-null) grid sized [GridWorld.cols] × [GridWorld.rows].
+List<List<TileType?>> createEmptyGrid() => List.generate(
+    GridWorld.cols, (_) => List.generate(GridWorld.rows, (_) => null));

--- a/test/services/github_feedback_client_test.dart
+++ b/test/services/github_feedback_client_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -131,6 +132,28 @@ void main() {
       final client = GitHubFeedbackClient.withToken('ghp_secret', httpClient: mockHttp);
       await client.createIssue('test', 'https://img.png');
       expect(capturedRequest?.headers['Authorization'], 'token ghp_secret');
+    });
+
+    test('uploadImage wraps SocketException as FeedbackClientException', () async {
+      final mockHttp = MockClient((_) async =>
+          throw const SocketException('OS Error: syscall, errno = 0'));
+
+      final client = GitHubFeedbackClient.withToken('ghp_test', httpClient: mockHttp);
+      expect(
+        () => client.uploadImage('img-1', _minimalPng),
+        throwsA(isA<FeedbackClientException>()),
+      );
+    });
+
+    test('createIssue wraps SocketException as FeedbackClientException', () async {
+      final mockHttp = MockClient((_) async =>
+          throw const SocketException('OS Error: syscall, errno = 0'));
+
+      final client = GitHubFeedbackClient.withToken('ghp_test', httpClient: mockHttp);
+      expect(
+        () => client.createIssue('desc', 'https://img.png'),
+        throwsA(isA<FeedbackClientException>()),
+      );
     });
   });
 }

--- a/test/services/github_feedback_client_test.dart
+++ b/test/services/github_feedback_client_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
@@ -65,7 +66,7 @@ void main() {
           http.Response('{"message":"Bad credentials"}', 403));
 
       final client = GitHubFeedbackClient.withToken('ghp_bad', httpClient: mockHttp);
-      expect(
+      await expectLater(
         () => client.uploadImage('img-1', _minimalPng),
         throwsA(isA<FeedbackClientException>().having(
           (e) => e.message,
@@ -80,7 +81,7 @@ void main() {
           http.Response('{"message":"Unprocessable Entity"}', 422));
 
       final client = GitHubFeedbackClient.withToken('ghp_test', httpClient: mockHttp);
-      expect(
+      await expectLater(
         () => client.uploadImage('img-1', _minimalPng),
         throwsA(isA<FeedbackClientException>()),
       );
@@ -109,7 +110,7 @@ void main() {
           http.Response('{"message":"Bad credentials"}', 403));
 
       final client = GitHubFeedbackClient.withToken('ghp_bad', httpClient: mockHttp);
-      expect(
+      await expectLater(
         () => client.createIssue('desc', 'https://img.png'),
         throwsA(isA<FeedbackClientException>().having(
           (e) => e.message,
@@ -139,7 +140,7 @@ void main() {
           throw const SocketException('OS Error: syscall, errno = 0'));
 
       final client = GitHubFeedbackClient.withToken('ghp_test', httpClient: mockHttp);
-      expect(
+      await expectLater(
         () => client.uploadImage('img-1', _minimalPng),
         throwsA(isA<FeedbackClientException>()),
       );
@@ -150,7 +151,29 @@ void main() {
           throw const SocketException('OS Error: syscall, errno = 0'));
 
       final client = GitHubFeedbackClient.withToken('ghp_test', httpClient: mockHttp);
-      expect(
+      await expectLater(
+        () => client.createIssue('desc', 'https://img.png'),
+        throwsA(isA<FeedbackClientException>()),
+      );
+    });
+
+    test('uploadImage wraps TimeoutException as FeedbackClientException', () async {
+      final mockHttp = MockClient((_) async =>
+          throw TimeoutException('Connection timed out'));
+
+      final client = GitHubFeedbackClient.withToken('ghp_test', httpClient: mockHttp);
+      await expectLater(
+        () => client.uploadImage('img-1', _minimalPng),
+        throwsA(isA<FeedbackClientException>()),
+      );
+    });
+
+    test('createIssue wraps TimeoutException as FeedbackClientException', () async {
+      final mockHttp = MockClient((_) async =>
+          throw TimeoutException('Connection timed out'));
+
+      final client = GitHubFeedbackClient.withToken('ghp_test', httpClient: mockHttp);
+      await expectLater(
         () => client.createIssue('desc', 'https://img.png'),
         throwsA(isA<FeedbackClientException>()),
       );


### PR DESCRIPTION
## Summary

Fixes [#112](https://github.com/alexsiri7/cosmic-match/issues/112) — unhandled stream error from `connectivity_plus` 7.x platform channel emitting "[Sentry] syscall" crashes.

The `FeedbackService.listenConnectivity()` listener was missing an `onError` handler. When the underlying Android `NetworkCallback` encounters a socket-level failure, the stream error propagates unhandled to the Sentry-wrapped zone and is recorded as a crash. Additionally, `GitHubFeedbackClient` HTTP calls had no timeout or error wrapping, allowing network errors to bypass the `FeedbackClientException` guard.

## Changes

### Root Cause Fix
- **`lib/services/feedback_service.dart`**: Added `onError` handler to the connectivity stream listener. Stream errors are now logged at warning level instead of propagating to Sentry.

### Secondary Fix (Dead Code Path)
- **`lib/services/github_feedback_client.dart`**: 
  - Added 15-second timeout to `uploadImage()` and `createIssue()` HTTP calls
  - Wrapped all network exceptions (SocketException, HandshakeException, TimeoutException) as `FeedbackClientException`
  - This prevents indefinite hangs on slow networks and ensures correct error message shown to users (even though these methods are currently dead code after #89)

### Tests
- **`test/services/github_feedback_client_test.dart`**: Added tests verifying that SocketException is wrapped as FeedbackClientException in both upload and issue creation paths

## Validation

✅ `flutter analyze` — no issues  
✅ `flutter test` — 224 tests passed  
✅ All changes follow existing patterns from `FeedbackService._postToWorker()`

## Testing Notes

1. Put device in airplane mode → submit feedback → should show "will retry when online"
2. Reconnect → connectivity listener should flush queue without Sentry events
3. Verify Sentry shows no new "[Sentry] syscall" events after deploying this fix

Fixes #112