### PR TITLE
ci: publish to Play Store production track on v* tag releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,28 @@ jobs:
           path: build/app/outputs/flutter-apk/app-release.apk
           retention-days: 7
 
+      - name: Publish to Play Store internal track
+        if: steps.keystore.outputs.used_real == 'yes' && github.ref == 'refs/heads/main' && secrets.PLAY_SERVICE_ACCOUNT_JSON != ''
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: net.interstellarai.cosmicmatch
+          releaseFiles: build/app/outputs/bundle/release/app-release.aab
+          track: internal
+          status: draft
+
+      - name: Notify prod landing
+        if: success() && github.ref == 'refs/heads/main' && steps.keystore.outputs.used_real == 'yes'
+        env:
+          NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}
+        run: |
+          [ -z "$NTFY_TOPIC" ] && exit 0
+          curl -s -o /dev/null \
+            -H "Title: cosmic-match landed in prod" \
+            -H "Tags: tada" \
+            -d "Cosmic Match uploaded to Play Store internal track ✓" \
+            "ntfy.sh/$NTFY_TOPIC"
+
       - name: Clean up signing credentials
         if: always()
         run: rm -f android/cosmic-match-release.jks android/key.properties

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
           retention-days: 7
 
       - name: Publish to Play Store internal track
-        if: steps.keystore.outputs.used_real == 'yes' && github.ref == 'refs/heads/main' && secrets.PLAY_SERVICE_ACCOUNT_JSON != ''
+        if: steps.keystore.outputs.used_real == 'yes' && github.ref == 'refs/heads/main'
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
           packageName: net.interstellarai.cosmicmatch
           releaseFiles: build/app/outputs/bundle/release/app-release.aab
           track: internal
-          status: completed
+          status: draft
           releaseName: ${{ env.BUILD_NAME }}
 
       - name: Publish to Play Store production (tag release)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: [main]
+    tags:
+      - 'v*'
   pull_request:
 
 permissions:
@@ -51,7 +53,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -68,6 +70,17 @@ jobs:
       - uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4.4.1
 
       - run: flutter pub get
+
+      - name: Resolve version
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            BUILD_NAME="${GITHUB_REF#refs/tags/v}"
+          else
+            BUILD_NAME="$(grep '^version:' pubspec.yaml | sed 's/version: //;s/+.*//')"
+          fi
+          BUILD_NUMBER=$(git rev-list --count HEAD)
+          echo "BUILD_NAME=$BUILD_NAME" >> "$GITHUB_ENV"
+          echo "BUILD_NUMBER=$BUILD_NUMBER" >> "$GITHUB_ENV"
 
       # Resolve signing keystore: try the real release keystore from secrets;
       # fall back to a CI-throwaway if the secret is missing or unreadable.
@@ -128,7 +141,7 @@ jobs:
         # --split-debug-info + --obfuscate produce the Dart debug symbols that
         # sentry_dart_plugin uploads in the next step, enabling server-side
         # symbolication of release stack traces.
-        run: flutter build appbundle --release --split-debug-info=build/symbols --obfuscate --dart-define=SENTRY_DSN=$SENTRY_DSN --dart-define=FEEDBACK_WORKER_URL=$FEEDBACK_WORKER_URL
+        run: flutter build appbundle --release --build-name=$BUILD_NAME --build-number=$BUILD_NUMBER --split-debug-info=build/symbols --obfuscate --dart-define=SENTRY_DSN=$SENTRY_DSN --dart-define=FEEDBACK_WORKER_URL=$FEEDBACK_WORKER_URL
 
       - name: Upload debug symbols to Sentry (AAB)
         env:
@@ -142,7 +155,7 @@ jobs:
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           FEEDBACK_WORKER_URL: ${{ vars.FEEDBACK_WORKER_URL || 'https://feedback.alexsiri7.workers.dev/' }}
-        run: flutter build apk --release --split-debug-info=build/symbols --obfuscate --dart-define=SENTRY_DSN=$SENTRY_DSN --dart-define=FEEDBACK_WORKER_URL=$FEEDBACK_WORKER_URL
+        run: flutter build apk --release --build-name=$BUILD_NAME --build-number=$BUILD_NUMBER --split-debug-info=build/symbols --obfuscate --dart-define=SENTRY_DSN=$SENTRY_DSN --dart-define=FEEDBACK_WORKER_URL=$FEEDBACK_WORKER_URL
 
       - name: Upload debug symbols to Sentry (APK)
         env:
@@ -182,8 +195,8 @@ jobs:
           path: build/app/outputs/flutter-apk/app-release.apk
           retention-days: 7
 
-      - name: Publish to Play Store internal track
-        if: steps.keystore.outputs.used_real == 'yes' && github.ref == 'refs/heads/main'
+      - name: Publish to Play Store internal track (non-tag)
+        if: steps.keystore.outputs.used_real == 'yes' && !startsWith(github.ref, 'refs/tags/v')
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
@@ -191,9 +204,31 @@ jobs:
           releaseFiles: build/app/outputs/bundle/release/app-release.aab
           track: internal
           status: draft
+          releaseName: ${{ env.BUILD_NAME }}
+
+      - name: Publish to Play Store production (tag release)
+        if: steps.keystore.outputs.used_real == 'yes' && startsWith(github.ref, 'refs/tags/v')
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: net.interstellarai.cosmicmatch
+          releaseFiles: build/app/outputs/bundle/release/app-release.aab
+          track: production
+          status: completed
+          releaseName: ${{ env.BUILD_NAME }}
+
+      - name: Create GitHub Release (tag pushes only)
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            build/app/outputs/bundle/release/app-release.aab
+            build/app/outputs/flutter-apk/app-release.apk
+          generate_release_notes: true
+          fail_on_unmatched_files: true
 
       - name: Notify prod landing
-        if: success() && github.ref == 'refs/heads/main' && steps.keystore.outputs.used_real == 'yes'
+        if: success() && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && steps.keystore.outputs.used_real == 'yes'
         env:
           NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
           packageName: net.interstellarai.cosmicmatch
           releaseFiles: build/app/outputs/bundle/release/app-release.aab
           track: internal
-          status: draft
+          status: completed
           releaseName: ${{ env.BUILD_NAME }}
 
       - name: Publish to Play Store production (tag release)


### PR DESCRIPTION
## Summary
- Non-tag pushes to \`main\` → internal track, draft (unchanged, for QA)
- \`v*\` tag pushes → production track, \`completed\` (auto-ships to all users)
- Adds version resolve step: build-name from tag, build-number from git commit count
- Adds GitHub Release creation on tag pushes

To release: \`git tag v1.0.0 && git push origin v1.0.0\`