### PR TITLE
feat: add Google Play flexible in-app update

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'screens/feedback_sheet.dart';
 import 'screens/game_screen.dart';
 import 'screens/home_screen.dart';
 import 'services/feedback_service.dart';
+import 'services/in_app_update_service.dart';
 import 'services/key_service.dart';
 import 'services/progress_service.dart';
 import 'services/sentry_smoke_service.dart';
@@ -110,11 +111,33 @@ class _CosmicMatchAppState extends State<CosmicMatchApp> {
   late final Match3Game _game;
   final _repaintBoundaryKey = GlobalKey();
   final _navigatorKey = GlobalKey<NavigatorState>();
+  final _scaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
+  final _updateService = InAppUpdateService();
 
   @override
   void initState() {
     super.initState();
     _game = widget.gameOverride ?? Match3Game(progressService: widget.progressService);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _updateService.checkAndStartFlexibleUpdate(
+        onUpdateDownloaded: _onUpdateDownloaded,
+      );
+    });
+  }
+
+  void _onUpdateDownloaded() {
+    final messenger = _scaffoldMessengerKey.currentState;
+    if (messenger == null) return;
+    messenger.showSnackBar(
+      SnackBar(
+        content: const Text('Update ready'),
+        duration: const Duration(days: 1),
+        action: SnackBarAction(
+          label: 'Restart',
+          onPressed: () => _updateService.completeFlexibleUpdate(),
+        ),
+      ),
+    );
   }
 
   Future<Uint8List> _captureScreenshot() async {
@@ -206,14 +229,18 @@ class _CosmicMatchAppState extends State<CosmicMatchApp> {
   Widget build(BuildContext context) {
     return MaterialApp(
       navigatorKey: _navigatorKey,
+      scaffoldMessengerKey: _scaffoldMessengerKey,
       title: 'Cosmic Match',
       theme: ThemeData.dark().copyWith(
         scaffoldBackgroundColor: const Color(0xFF0D0A1A),
       ),
-      home: SafeArea(
-        child: RepaintBoundary(
-          key: _repaintBoundaryKey,
-          child: _buildScreen(),
+      home: Scaffold(
+        backgroundColor: Colors.transparent,
+        body: SafeArea(
+          child: RepaintBoundary(
+            key: _repaintBoundaryKey,
+            child: _buildScreen(),
+          ),
         ),
       ),
     );

--- a/lib/services/in_app_update_service.dart
+++ b/lib/services/in_app_update_service.dart
@@ -1,0 +1,32 @@
+import 'dart:io';
+
+import 'package:in_app_update/in_app_update.dart';
+
+import '../core/logger.dart';
+
+class InAppUpdateService {
+  Future<void> checkAndStartFlexibleUpdate({
+    required void Function() onUpdateDownloaded,
+  }) async {
+    if (!Platform.isAndroid) return;
+    try {
+      final info = await InAppUpdate.checkForUpdate();
+      if (info.updateAvailability != UpdateAvailability.updateAvailable) return;
+      final result = await InAppUpdate.startFlexibleUpdate();
+      if (result == AppUpdateResult.success) {
+        onUpdateDownloaded();
+      }
+    } catch (e, stack) {
+      gameLogger.w('InAppUpdateService: update check failed', error: e, stackTrace: stack);
+    }
+  }
+
+  Future<void> completeFlexibleUpdate() async {
+    if (!Platform.isAndroid) return;
+    try {
+      await InAppUpdate.completeFlexibleUpdate();
+    } catch (e, stack) {
+      gameLogger.w('InAppUpdateService: completeFlexibleUpdate failed', error: e, stackTrace: stack);
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   sentry_flutter: ^8.12.0
   package_info_plus: ^9.0.1
   google_fonts: ^8.0.2
+  in_app_update: ^4.2.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- Adds `in_app_update ^4.2.3` dependency to `pubspec.yaml`
- New `InAppUpdateService` in `lib/services/` checks for a Play Store update on app start and runs the flexible update flow (download in background)
- On download completion, shows a persistent snackbar with a "Restart" action that calls `completeFlexibleUpdate()`
- Android-only guard (`Platform.isAndroid`) prevents any effect on other platforms
- Wired via `scaffoldMessengerKey` on `MaterialApp` so the snackbar doesn't require a navigator context

## Test plan
- [ ] Release build on Android: no update available → no snackbar shown
- [ ] Release build with a pending update in Play internal track → snackbar appears after download, tap Restart applies update
- [ ] iOS/non-Android build → no crash, no update logic executed