### PR TITLE
ci: publish to Play Store production track on v* tag releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: [main]
+    tags:
+      - 'v*'
   pull_request:
 
 permissions:
@@ -51,9 +53,11 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -68,6 +72,17 @@ jobs:
       - uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4.4.1
 
       - run: flutter pub get
+
+      - name: Resolve version
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            BUILD_NAME="${GITHUB_REF#refs/tags/v}"
+          else
+            BUILD_NAME="$(grep '^version:' pubspec.yaml | sed 's/version: //;s/+.*//')"
+          fi
+          BUILD_NUMBER=$(git rev-list --count HEAD)
+          echo "BUILD_NAME=$BUILD_NAME" >> "$GITHUB_ENV"
+          echo "BUILD_NUMBER=$BUILD_NUMBER" >> "$GITHUB_ENV"
 
       # Resolve signing keystore: try the real release keystore from secrets;
       # fall back to a CI-throwaway if the secret is missing or unreadable.
@@ -128,7 +143,7 @@ jobs:
         # --split-debug-info + --obfuscate produce the Dart debug symbols that
         # sentry_dart_plugin uploads in the next step, enabling server-side
         # symbolication of release stack traces.
-        run: flutter build appbundle --release --split-debug-info=build/symbols --obfuscate --dart-define=SENTRY_DSN=$SENTRY_DSN --dart-define=FEEDBACK_WORKER_URL=$FEEDBACK_WORKER_URL
+        run: flutter build appbundle --release --build-name=$BUILD_NAME --build-number=$BUILD_NUMBER --split-debug-info=build/symbols --obfuscate --dart-define=SENTRY_DSN=$SENTRY_DSN --dart-define=FEEDBACK_WORKER_URL=$FEEDBACK_WORKER_URL
 
       - name: Upload debug symbols to Sentry (AAB)
         env:
@@ -142,7 +157,7 @@ jobs:
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           FEEDBACK_WORKER_URL: ${{ vars.FEEDBACK_WORKER_URL || 'https://feedback.alexsiri7.workers.dev/' }}
-        run: flutter build apk --release --split-debug-info=build/symbols --obfuscate --dart-define=SENTRY_DSN=$SENTRY_DSN --dart-define=FEEDBACK_WORKER_URL=$FEEDBACK_WORKER_URL
+        run: flutter build apk --release --build-name=$BUILD_NAME --build-number=$BUILD_NUMBER --split-debug-info=build/symbols --obfuscate --dart-define=SENTRY_DSN=$SENTRY_DSN --dart-define=FEEDBACK_WORKER_URL=$FEEDBACK_WORKER_URL
 
       - name: Upload debug symbols to Sentry (APK)
         env:
@@ -182,8 +197,8 @@ jobs:
           path: build/app/outputs/flutter-apk/app-release.apk
           retention-days: 7
 
-      - name: Publish to Play Store internal track
-        if: steps.keystore.outputs.used_real == 'yes' && github.ref == 'refs/heads/main'
+      - name: Publish to Play Store internal track (non-tag)
+        if: steps.keystore.outputs.used_real == 'yes' && !startsWith(github.ref, 'refs/tags/v')
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
@@ -191,9 +206,31 @@ jobs:
           releaseFiles: build/app/outputs/bundle/release/app-release.aab
           track: internal
           status: draft
+          releaseName: ${{ env.BUILD_NAME }}
+
+      - name: Publish to Play Store production (tag release)
+        if: steps.keystore.outputs.used_real == 'yes' && startsWith(github.ref, 'refs/tags/v')
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: net.interstellarai.cosmicmatch
+          releaseFiles: build/app/outputs/bundle/release/app-release.aab
+          track: production
+          status: completed
+          releaseName: ${{ env.BUILD_NAME }}
+
+      - name: Create GitHub Release (tag pushes only)
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            build/app/outputs/bundle/release/app-release.aab
+            build/app/outputs/flutter-apk/app-release.apk
+          generate_release_notes: true
+          fail_on_unmatched_files: true
 
       - name: Notify prod landing
-        if: success() && github.ref == 'refs/heads/main' && steps.keystore.outputs.used_real == 'yes'
+        if: success() && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && steps.keystore.outputs.used_real == 'yes'
         env:
           NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}
         run: |
@@ -201,7 +238,7 @@ jobs:
           curl -s -o /dev/null \
             -H "Title: cosmic-match landed in prod" \
             -H "Tags: tada" \
-            -d "Cosmic Match uploaded to Play Store internal track ✓" \
+            -d "Cosmic Match uploaded to Play Store ✓" \
             "ntfy.sh/$NTFY_TOPIC"
 
       - name: Clean up signing credentials


### PR DESCRIPTION
## Summary
- Non-tag pushes to \`main\` → internal track, draft (for QA)
- \`v*\` tag pushes → production track, \`completed\` (auto-ships to all users)
- Adds version resolve step: build-name from tag, build-number from git commit count
- Adds GitHub Release creation on tag pushes

Replaces #122 (that branch had rebase conflicts from old history).

To release: \`git tag v1.0.0 && git push origin v1.0.0\`