### PR TITLE
fix: prevent HomeScreen tagline overflow with google_fonts 8.1.0

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -82,7 +82,7 @@ class HomeScreen extends StatelessWidget {
                         ),
                       ),
                       const SizedBox(width: 8),
-                      Expanded(
+                      Flexible(
                         child: Text(
                           '50 levels · 5 galaxies · portrait only',
                           style: GoogleFonts.ibmPlexMono(


### PR DESCRIPTION
## Summary

- Wraps the `'50 levels · 5 galaxies · portrait only'` `Text` in a `Flexible` widget on the HomeScreen
- IBM Plex Mono metrics changed in google_fonts 8.1.0, pushing this unbounded `Row` 2.3px past the 272px content width on small emulator screens
- This caused the `scripted_match_test` integration test to fail with a `RenderFlex overflowed` error after PR #131 merged

## Test plan

- [ ] `flutter analyze` — clean
- [ ] Integration test `scripted_match_test.dart` should pass on emulator (no more overflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)