### PR TITLE
Fix: enforce 10-char minimum on in-app feedback

### DIFF
--- a/lib/core/constants.dart
+++ b/lib/core/constants.dart
@@ -12,3 +12,8 @@ final kTransparentPng = Uint8List.fromList([
   0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42,
   0x60, 0x82,
 ]);
+
+/// Minimum length (after trim) for a user-supplied feedback description.
+/// Enforced both in the UI (`FeedbackSheet`) and the service (`FeedbackService`)
+/// to keep low-signal reports out of the GitHub pipeline.
+const int kMinFeedbackMessageLength = 10;

--- a/lib/screens/feedback_sheet.dart
+++ b/lib/screens/feedback_sheet.dart
@@ -5,6 +5,7 @@ import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
+import '../core/constants.dart';
 import '../core/logger.dart';
 import '../game/theme/app_theme.dart';
 
@@ -62,7 +63,9 @@ class _FeedbackSheetState extends State<_FeedbackSheet> {
     super.dispose();
   }
 
-  bool get _canSubmit => _descController.text.trim().isNotEmpty && !_submitting;
+  bool get _canSubmit =>
+      _descController.text.trim().length >= kMinFeedbackMessageLength &&
+      !_submitting;
 
   Future<void> _handleSubmit() async {
     if (!_canSubmit) return;
@@ -279,6 +282,11 @@ class _FeedbackSheetState extends State<_FeedbackSheet> {
                     hintStyle: GoogleFonts.ibmPlexMono(
                       fontSize: 13,
                       color: Colors.white.withValues(alpha: 0.4),
+                    ),
+                    helperText: 'At least $kMinFeedbackMessageLength characters',
+                    helperStyle: GoogleFonts.ibmPlexMono(
+                      fontSize: 11,
+                      color: Colors.white.withValues(alpha: 0.5),
                     ),
                     filled: true,
                     fillColor: Colors.white.withValues(alpha: 0.06),

--- a/lib/services/feedback_service.dart
+++ b/lib/services/feedback_service.dart
@@ -54,10 +54,11 @@ class FeedbackService {
       return;
     }
 
-    if (message.trim().length < kMinFeedbackMessageLength) {
+    final trimmedLen = message.trim().length;
+    if (trimmedLen < kMinFeedbackMessageLength) {
       gameLogger.w(
         'FeedbackService.submit: message too short '
-        '(${message.trim().length} < $kMinFeedbackMessageLength) — skipping',
+        '($trimmedLen < $kMinFeedbackMessageLength) — skipping',
       );
       return;
     }

--- a/lib/services/feedback_service.dart
+++ b/lib/services/feedback_service.dart
@@ -6,6 +6,7 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:hive/hive.dart';
 import 'package:http/http.dart' as http;
 
+import '../core/constants.dart';
 import '../core/logger.dart';
 import '../models/pending_feedback.dart';
 
@@ -50,6 +51,14 @@ class FeedbackService {
   }) async {
     if (workerUrl.isEmpty) {
       gameLogger.w('FeedbackService.submit: workerUrl is empty — skipping');
+      return;
+    }
+
+    if (message.trim().length < kMinFeedbackMessageLength) {
+      gameLogger.w(
+        'FeedbackService.submit: message too short '
+        '(${message.trim().length} < $kMinFeedbackMessageLength) — skipping',
+      );
       return;
     }
 

--- a/test/services/feedback_service_test.dart
+++ b/test/services/feedback_service_test.dart
@@ -350,6 +350,61 @@ void main() {
       final box = await Hive.openBox('feedback_worker_queue');
       expect(box.length, 0);
     });
+
+    test('skips POST and does not enqueue when message is whitespace-only', () async {
+      // Pins the trim() contract: 10 spaces trim to 0 chars and must be
+      // rejected. Without this test, swapping `.trim().length` for `.length`
+      // in the guard would slip past the suite.
+      var posted = false;
+      final client = MockClient((_) async {
+        posted = true;
+        return http.Response('', 201);
+      });
+      final service = FeedbackService(
+        workerUrl: 'https://example.com/feedback',
+        httpClient: client,
+      );
+
+      await service.submit(
+        type: 'bug',
+        message: '          ', // 10 spaces — trims to 0
+        screenshotB64: '',
+        appVersion: '1.0.0+1',
+        os: 'android',
+        device: 'Pixel',
+      );
+
+      expect(posted, isFalse);
+      final box = await Hive.openBox('feedback_worker_queue');
+      expect(box.length, 0);
+    });
+
+    test('accepts message at the exact minimum length boundary', () async {
+      // Pins the `<` boundary: an off-by-one regression to `<=` would silently
+      // drop 10-char submissions that the UI accepts.
+      var posted = false;
+      final client = MockClient((_) async {
+        posted = true;
+        return http.Response('{"url": "https://github.com/issue/1"}', 201);
+      });
+      final service = FeedbackService(
+        workerUrl: 'https://example.com/feedback',
+        httpClient: client,
+      );
+
+      await service.submit(
+        type: 'bug',
+        message: 'just right', // exactly 10 chars
+        screenshotB64: '',
+        appVersion: '1.0.0+1',
+        os: 'android',
+        device: 'Pixel',
+      );
+
+      expect(posted, isTrue);
+      final box = await Hive.openBox('feedback_worker_queue');
+      expect(box.length, 0);
+    });
   });
 
   group('FeedbackService.flushQueue', () {

--- a/test/services/feedback_service_test.dart
+++ b/test/services/feedback_service_test.dart
@@ -93,7 +93,7 @@ void main() {
       final item = PendingFeedback(
         id: 'q-1',
         type: 'bug',
-        message: 'test',
+        message: 'test message',
         screenshotB64: 'img',
         appVersion: '1.0.0+1',
         os: 'android',
@@ -107,7 +107,7 @@ void main() {
       final raw = box.get('q-1') as Map;
       final restored = PendingFeedback.fromMap(Map<String, dynamic>.from(raw));
       expect(restored.id, 'q-1');
-      expect(restored.message, 'test');
+      expect(restored.message, 'test message');
     });
 
     test('multiple items can be stored and iterated', () async {
@@ -117,7 +117,7 @@ void main() {
         final item = PendingFeedback(
           id: 'item-$i',
           type: 'bug',
-          message: 'msg $i',
+          message: 'queued msg $i',
           screenshotB64: '',
           appVersion: '1.0.0+1',
           os: 'android',
@@ -158,7 +158,7 @@ void main() {
 
       await service.submit(
         type: 'bug',
-        message: 'test',
+        message: 'test message',
         screenshotB64: '',
         appVersion: '1.0.0+1',
         os: 'android',
@@ -181,7 +181,7 @@ void main() {
 
       await service.submit(
         type: 'bug',
-        message: 'test',
+        message: 'test message',
         screenshotB64: '',
         appVersion: '1.0.0+1',
         os: 'android',
@@ -201,7 +201,7 @@ void main() {
 
       await service.submit(
         type: 'bug',
-        message: 'test',
+        message: 'test message',
         screenshotB64: '',
         appVersion: '1.0.0+1',
         os: 'android',
@@ -221,7 +221,7 @@ void main() {
 
       await service.submit(
         type: 'bug',
-        message: 'test',
+        message: 'test message',
         screenshotB64: '',
         appVersion: '1.0.0+1',
         os: 'android',
@@ -261,7 +261,7 @@ void main() {
 
       await service.submit(
         type: 'bug',
-        message: 'test',
+        message: 'test message',
         screenshotB64: '',
         appVersion: '1.0.0+1',
         os: 'android',
@@ -277,7 +277,7 @@ void main() {
 
       await service.submit(
         type: 'bug',
-        message: 'test',
+        message: 'test message',
         screenshotB64: '',
         appVersion: '1.0.0+1',
         os: 'android',
@@ -299,7 +299,7 @@ void main() {
       for (int i = 0; i < 20; i++) {
         await service.submit(
           type: 'bug',
-          message: 'msg $i',
+          message: 'queued msg $i',
           screenshotB64: '',
           appVersion: '1.0.0+1',
           os: 'android',
@@ -314,7 +314,7 @@ void main() {
       // Submit one more — oldest should be evicted
       await service.submit(
         type: 'bug',
-        message: 'overflow',
+        message: 'overflow item',
         screenshotB64: '',
         appVersion: '1.0.0+1',
         os: 'android',
@@ -323,7 +323,32 @@ void main() {
 
       expect(box.length, 20);
       expect((box.getAt(0) as Map)['message'], isNot(firstMsg)); // oldest gone
-      expect((box.getAt(box.length - 1) as Map)['message'], 'overflow');
+      expect((box.getAt(box.length - 1) as Map)['message'], 'overflow item');
+    });
+
+    test('skips POST and does not enqueue when message is too short', () async {
+      var posted = false;
+      final client = MockClient((_) async {
+        posted = true;
+        return http.Response('', 201);
+      });
+      final service = FeedbackService(
+        workerUrl: 'https://example.com/feedback',
+        httpClient: client,
+      );
+
+      await service.submit(
+        type: 'bug',
+        message: 'too short', // 9 chars after trim
+        screenshotB64: '',
+        appVersion: '1.0.0+1',
+        os: 'android',
+        device: 'Pixel',
+      );
+
+      expect(posted, isFalse);
+      final box = await Hive.openBox('feedback_worker_queue');
+      expect(box.length, 0);
     });
   });
 

--- a/test/widgets/feedback_sheet_test.dart
+++ b/test/widgets/feedback_sheet_test.dart
@@ -104,6 +104,40 @@ void main() {
       await tester.enterText(find.byType(TextField), 'just right');
       await tester.pump();
       expect(tester.widget<ElevatedButton>(submitFinder).onPressed, isNotNull);
+
+      // Whitespace-only (10 spaces) — trimmed length is 0, must stay disabled.
+      await tester.enterText(find.byType(TextField), '          ');
+      await tester.pump();
+      expect(tester.widget<ElevatedButton>(submitFinder).onPressed, isNull,
+          reason: 'whitespace-only must not satisfy the 10-char minimum');
+
+      // Surrounding whitespace around a 9-char body — trimmed length is 9,
+      // must stay disabled. Pins the UI-side `.trim()` semantics.
+      await tester.enterText(find.byType(TextField), '  too short  ');
+      await tester.pump();
+      expect(tester.widget<ElevatedButton>(submitFinder).onPressed, isNull,
+          reason: 'trimmed length is 9; surrounding whitespace must not satisfy the gate');
+    },
+  );
+
+  testWidgets(
+    'feedback sheet shows helper text describing the minimum length',
+    (tester) async {
+      await tester.pumpWidget(ProviderScope(
+        child: CosmicMatchApp(
+          progressService: ProgressService(),
+          feedbackService: FeedbackService(workerUrl: 'http://test'),
+          gameOverride: Match3Game(progressService: null),
+        ),
+      ));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Send feedback'));
+      await tester.pumpAndSettle();
+
+      // Couples helper-text copy to the constant — a restyle that drops or
+      // hides `helperText` would otherwise leave Submit silently disabled
+      // with no on-screen explanation.
+      expect(find.text('At least 10 characters'), findsOneWidget);
     },
   );
 }

--- a/test/widgets/feedback_sheet_test.dart
+++ b/test/widgets/feedback_sheet_test.dart
@@ -74,4 +74,36 @@ void main() {
       expect(find.byIcon(Icons.pan_tool), findsOneWidget);
     },
   );
+
+  testWidgets(
+    'feedback sheet Submit button is disabled until description meets minimum length',
+    (tester) async {
+      await tester.pumpWidget(ProviderScope(
+        child: CosmicMatchApp(
+          progressService: ProgressService(),
+          feedbackService: FeedbackService(workerUrl: 'http://test'),
+          gameOverride: Match3Game(progressService: null),
+        ),
+      ));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Send feedback'));
+      await tester.pumpAndSettle();
+
+      final submitFinder = find.widgetWithText(ElevatedButton, 'Submit');
+      expect(submitFinder, findsOneWidget);
+
+      // Initially disabled (empty description).
+      expect(tester.widget<ElevatedButton>(submitFinder).onPressed, isNull);
+
+      // 9 chars — still below threshold (10).
+      await tester.enterText(find.byType(TextField), 'too short');
+      await tester.pump();
+      expect(tester.widget<ElevatedButton>(submitFinder).onPressed, isNull);
+
+      // 10 chars — now enabled.
+      await tester.enterText(find.byType(TextField), 'just right');
+      await tester.pump();
+      expect(tester.widget<ElevatedButton>(submitFinder).onPressed, isNotNull);
+    },
+  );
 }


### PR DESCRIPTION
## Summary

Issue #139 was filed via the in-app `FeedbackSheet` → `FeedbackService` → Cloudflare Worker pipeline with effectively empty content (title `Bug: Test bug report`, body `Test bug report`). The Submit button was enabled on any non-empty description, and `FeedbackService.submit()` had no message-length guard, so low-signal reports flowed straight through to the GitHub pipeline.

This PR adds a minimum-content invariant (`kMinFeedbackMessageLength = 10`) at both the UI and service layers, with a single shared constant as the source of truth.

Fixes #139

## Root Cause

- `lib/screens/feedback_sheet.dart:65` — `_canSubmit` used `.isNotEmpty` rather than a length floor, so any single non-whitespace character passed.
- `lib/services/feedback_service.dart:43-73` — only guarded against `workerUrl.isEmpty`; no message-content invariant. UI was the sole enforcement point.
- Long-standing gap (since `1cf129a` "security: route in-app feedback through Cloudflare Worker (#89)"), not a regression.

Full 5-whys + evidence chain in `investigation.md`.

## Changes

| File | Action | Purpose |
|------|--------|---------|
| `lib/core/constants.dart` | +5 | New shared `kMinFeedbackMessageLength = 10` constant |
| `lib/screens/feedback_sheet.dart` | +10/-1 | Tighten `_canSubmit` to require `trim().length >= min`; add `helperText: "At least 10 characters"` under the description field |
| `lib/services/feedback_service.dart` | +9 | Defense-in-depth early-return guard mirroring the existing `workerUrl.isEmpty` pattern |
| `test/widgets/feedback_sheet_test.dart` | +32 | Widget test covering disabled-at-empty / 9-char / enabled-at-10-char |
| `test/services/feedback_service_test.dart` | +37/-12 | New service test asserting too-short messages neither POST nor enqueue; existing tests updated to use 10+ char messages so they keep exercising the behavior they claim to test |

Total: 5 files, +92 / -13.

## Deviation from Plan

The investigation called for a single new service test. In practice, several existing tests in `FeedbackService.submit` and `FeedbackService queue (Hive)` had to be updated to use messages ≥10 chars. Without that update the `'enforces 20-item cap'` test would fail outright, and several status-code branching tests would silently short-circuit at the new guard — green for the wrong reason. Minimal-but-meaningful updates were made to keep the suite faithful.

## Validation

| Check | Result |
|-------|--------|
| `flutter analyze` | ✅ No issues found (3.3s) |
| `flutter test` (full suite) | ✅ 232 passed, 0 failed |
| `flutter build apk --debug` | ⚠️ Skipped — local JDK 25 incompatibility with bundled Kotlin (`java.lang.IllegalArgumentException: 25.0.2` at `KotlinCoreEnvironment` init, before any project code). Pre-existing env issue on this worktree host; this PR touches pure Dart only. CI uses a pinned JDK via the workflow. |

The orange `CascadeController: maxDepth (20) reached` lines in `cascade_controller_test.dart` are the SEC-008 cap intentionally tripping inside the test, not failures.

### Manual verification (deferred to review)

1. Open feedback sheet from the home screen.
2. Confirm Submit is disabled with helper text "At least 10 characters" visible.
3. Type 9 characters — Submit stays disabled.
4. Type a 10th character — Submit enables.
5. Submit and confirm a real GitHub issue appears.
6. Reopen and try whitespace-only text — Submit stays disabled.

## Scope Boundaries

**Out of scope** (tracked as web-research follow-ups):
- Server-side validation in the Cloudflare Worker (separate repo).
- `needs-more-info` triage label + `actions/stale` workflow.
- Worker-side rate limiting.
- Replacing the in-app flow with Wiredash / Instabug / Sentry user-feedback.
- Any change to `PendingFeedback` model fields or CRC32 canonicalization (in-scope guarantee preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)