### PR TITLE
Fix: drop unactionable Sentry "Abort" channel-buffer events

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ lib/
   core/           # Cross-cutting primitives shared across layers
                   #   logger.dart — `gameLogger` (single project-wide logger instance)
                   #   constants.dart — `kTransparentPng` (1×1 PNG fallback for screenshot capture)
+                  #   sentry_filters.dart — `dropUnactionableAbort` (Sentry beforeSend filter for #145)
   game/           # Flame game, FSM, world, components
                   #   Input/FSM enums (GamePhase, SwipeDirection) defined in match3_game.dart
     theme/        # Tile color palette constants (kTilePalette — derived from TileType.colorValue;

--- a/lib/core/sentry_filters.dart
+++ b/lib/core/sentry_filters.dart
@@ -1,9 +1,15 @@
 import 'package:sentry_flutter/sentry_flutter.dart';
 
 /// Drops Sentry events that are clearly symbolication artifacts:
-/// a single exception with value "Abort" (case-insensitive) and a stack
-/// trace whose only frame is the engine dispatch site
-/// `_ChannelCallbackRecord.invoke` in `channel_buffers.dart`.
+/// a single exception with value "Abort" (case-insensitive) whose stack
+/// trace has 1 or 2 frames, all of which point at the engine dispatch
+/// site `_ChannelCallbackRecord.invoke` in `channel_buffers.dart`.
+///
+/// The 1-or-2-frame window covers the two observed Sentry encodings of
+/// the same crash: (a) just the dispatch frame, or (b) the dispatch
+/// frame plus one adjacent synthetic frame inserted by the reporter.
+/// Anything with three or more frames — or with an empty/missing stack
+/// trace — is treated as a real crash and passes through.
 ///
 /// These events carry no actionable signal — the user-code frames have
 /// been stripped by obfuscation/missing symbols. Dropping them here
@@ -20,7 +26,10 @@ SentryEvent? dropUnactionableAbort(SentryEvent event, Hint hint) {
   if (value != 'abort') return event;
 
   final frames = exception.stackTrace?.frames ?? const <SentryStackFrame>[];
-  if (frames.length > 2) return event;
+  // Empty/null frames must not match: Iterable.every is vacuously true on []
+  // and would otherwise silently drop frameless Abort events the filter was
+  // never meant to suppress.
+  if (frames.isEmpty || frames.length > 2) return event;
 
   final hasOnlyEngineFrame = frames.every((f) {
     final fn = f.function ?? '';

--- a/lib/core/sentry_filters.dart
+++ b/lib/core/sentry_filters.dart
@@ -1,0 +1,33 @@
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+/// Drops Sentry events that are clearly symbolication artifacts:
+/// a single exception with value "Abort" (case-insensitive) and a stack
+/// trace whose only frame is the engine dispatch site
+/// `_ChannelCallbackRecord.invoke` in `channel_buffers.dart`.
+///
+/// These events carry no actionable signal — the user-code frames have
+/// been stripped by obfuscation/missing symbols. Dropping them here
+/// prevents sentry-bridge from re-filing the same GitHub issue every
+/// time the shape reoccurs (see issue #145).
+///
+/// Pass-through for any event that does not match this exact shape.
+SentryEvent? dropUnactionableAbort(SentryEvent event, Hint hint) {
+  final exceptions = event.exceptions ?? const <SentryException>[];
+  if (exceptions.length != 1) return event;
+
+  final exception = exceptions.first;
+  final value = exception.value?.trim().toLowerCase();
+  if (value != 'abort') return event;
+
+  final frames = exception.stackTrace?.frames ?? const <SentryStackFrame>[];
+  if (frames.length > 2) return event;
+
+  final hasOnlyEngineFrame = frames.every((f) {
+    final fn = f.function ?? '';
+    final file = f.fileName ?? '';
+    return fn.contains('_ChannelCallbackRecord') &&
+        file.contains('channel_buffers.dart');
+  });
+
+  return hasOnlyEngineFrame ? null : event;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'core/constants.dart';
 import 'core/logger.dart';
+import 'core/sentry_filters.dart';
 import 'game/match3_game.dart';
 import 'screens/feedback_sheet.dart';
 import 'screens/game_screen.dart';
@@ -66,6 +67,7 @@ Future<void> main() async {
         options.tracesSampleRate = 0.0;
         options.sendDefaultPii = false;
         options.attachScreenshot = false;
+        options.beforeSend = dropUnactionableAbort;
       },
       appRunner: launch,
     );

--- a/test/core/sentry_filters_test.dart
+++ b/test/core/sentry_filters_test.dart
@@ -117,5 +117,60 @@ void main() {
       final event = SentryEvent();
       expect(dropUnactionableAbort(event, hint), isNotNull);
     });
+
+    test('passes through Abort with null stackTrace', () {
+      final event = SentryEvent(
+        exceptions: [SentryException(type: 'Exception', value: 'Abort')],
+      );
+      expect(dropUnactionableAbort(event, hint), isNotNull);
+    });
+
+    test('passes through Abort with empty frames list', () {
+      final event = _eventWith(value: 'Abort', frames: const []);
+      expect(dropUnactionableAbort(event, hint), isNotNull);
+    });
+
+    test('drops Abort with two engine-only frames', () {
+      final event = _eventWith(
+        value: 'Abort',
+        frames: [
+          SentryStackFrame(
+            function: '_ChannelCallbackRecord.invoke',
+            fileName: 'channel_buffers.dart',
+          ),
+          SentryStackFrame(
+            function: '_ChannelCallbackRecord.invoke',
+            fileName: 'channel_buffers.dart',
+          ),
+        ],
+      );
+      expect(dropUnactionableAbort(event, hint), isNull);
+    });
+
+    test('passes through 2-frame Abort where one frame is user code', () {
+      final event = _eventWith(
+        value: 'Abort',
+        frames: [
+          SentryStackFrame(
+            function: '_ChannelCallbackRecord.invoke',
+            fileName: 'channel_buffers.dart',
+          ),
+          SentryStackFrame(
+            function: 'PluginX.handler',
+            fileName: 'plugin_x.dart',
+          ),
+        ],
+      );
+      expect(dropUnactionableAbort(event, hint), isNotNull);
+    });
+
+    test('passes through Abort whose only frame has null function and fileName',
+        () {
+      final event = _eventWith(
+        value: 'Abort',
+        frames: [SentryStackFrame()],
+      );
+      expect(dropUnactionableAbort(event, hint), isNotNull);
+    });
   });
 }

--- a/test/core/sentry_filters_test.dart
+++ b/test/core/sentry_filters_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:cosmic_match/core/sentry_filters.dart';
+
+SentryEvent _eventWith({
+  required String value,
+  required List<SentryStackFrame> frames,
+}) {
+  return SentryEvent(
+    exceptions: [
+      SentryException(
+        type: 'Exception',
+        value: value,
+        stackTrace: SentryStackTrace(frames: frames),
+      ),
+    ],
+  );
+}
+
+void main() {
+  final hint = Hint();
+
+  group('dropUnactionableAbort', () {
+    test('drops single-frame channel_buffers Abort event', () {
+      final event = _eventWith(
+        value: 'Abort',
+        frames: [
+          SentryStackFrame(
+            function: '_ChannelCallbackRecord.invoke',
+            fileName: 'channel_buffers.dart',
+          ),
+        ],
+      );
+      expect(dropUnactionableAbort(event, hint), isNull);
+    });
+
+    test('drops case-insensitive "abort" with surrounding whitespace', () {
+      final event = _eventWith(
+        value: '  abort  ',
+        frames: [
+          SentryStackFrame(
+            function: '_ChannelCallbackRecord.invoke',
+            fileName: 'channel_buffers.dart',
+          ),
+        ],
+      );
+      expect(dropUnactionableAbort(event, hint), isNull);
+    });
+
+    test('passes through Abort with additional user frames', () {
+      final event = _eventWith(
+        value: 'Abort',
+        frames: [
+          SentryStackFrame(
+            function: 'MyService.doThing',
+            fileName: 'my_service.dart',
+          ),
+          SentryStackFrame(
+            function: '_ChannelCallbackRecord.invoke',
+            fileName: 'channel_buffers.dart',
+          ),
+          SentryStackFrame(
+            function: 'PluginX.handler',
+            fileName: 'plugin_x.dart',
+          ),
+        ],
+      );
+      expect(dropUnactionableAbort(event, hint), isNotNull);
+    });
+
+    test('passes through events with a different exception value', () {
+      final event = _eventWith(
+        value: 'StateError: bad state',
+        frames: [
+          SentryStackFrame(
+            function: '_ChannelCallbackRecord.invoke',
+            fileName: 'channel_buffers.dart',
+          ),
+        ],
+      );
+      expect(dropUnactionableAbort(event, hint), isNotNull);
+    });
+
+    test('passes through events whose top frame is not channel_buffers', () {
+      final event = _eventWith(
+        value: 'Abort',
+        frames: [
+          SentryStackFrame(
+            function: 'someOtherEngine.fn',
+            fileName: 'other_engine.dart',
+          ),
+        ],
+      );
+      expect(dropUnactionableAbort(event, hint), isNotNull);
+    });
+
+    test('passes through events with multiple exceptions', () {
+      final event = SentryEvent(
+        exceptions: [
+          SentryException(
+            type: 'Exception',
+            value: 'Abort',
+            stackTrace: SentryStackTrace(frames: [
+              SentryStackFrame(
+                function: '_ChannelCallbackRecord.invoke',
+                fileName: 'channel_buffers.dart',
+              ),
+            ]),
+          ),
+          SentryException(type: 'Exception', value: 'Other'),
+        ],
+      );
+      expect(dropUnactionableAbort(event, hint), isNotNull);
+    });
+
+    test('passes through events with no exceptions', () {
+      final event = SentryEvent();
+      expect(dropUnactionableAbort(event, hint), isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #145.

A Sentry event titled `_ChannelCallbackRecord.invoke` with the bare value `"Abort"` and a single engine frame in `dart:ui/channel_buffers.dart` was being auto-filed as a GitHub issue by sentry-bridge. The frame is the dispatch site for every platform-channel callback — not user code — and the shape is the canonical symbolication-failure pattern (an exception inside a plugin callback whose user frames have been stripped). It carries no actionable signal but kept re-creating duplicate sentry-bridge issues because `SentryFlutter.init` had no `beforeSend` filter.

This PR adds a narrow `beforeSend` filter that drops events matching exactly that shape and passes everything else through unchanged.

## Changes

- **`lib/core/sentry_filters.dart`** (NEW, +33): top-level `dropUnactionableAbort(SentryEvent, Hint)` helper. Drops events with a single exception whose value is `"abort"` (trimmed/lowercased), with ≤2 stack frames, where every frame matches `_ChannelCallbackRecord` in `channel_buffers.dart`. Pulled out as a top-level function so it is unit-testable without booting the Sentry SDK.
- **`lib/main.dart`** (UPDATE, +2): import the helper and register it via `options.beforeSend = dropUnactionableAbort` inside `SentryFlutter.init`.
- **`test/core/sentry_filters_test.dart`** (NEW, +121, 7 tests): verifies the filter drops the canonical shape (incl. case-insensitive / whitespace) and passes through events with extra frames, different values, different top frames, multiple exceptions, or no exceptions.

## Why this shape, this narrow

The filter is deliberately conservative. Any deviation — extra user frames, a non-`abort` value, a different top frame, or multiple exceptions — passes through unchanged, so a real plugin crash that happens to surface through `_ChannelCallbackRecord.invoke` is still reported. The narrowing is on **both** the function name (`_ChannelCallbackRecord`) and the file name (`channel_buffers.dart`) so other engine frames cannot accidentally match.

The symbol-upload pipeline (#138) is already correct going forward, but events captured by older builds cannot be retroactively symbolicated; this filter prevents the same un-symbolicatable shape from re-triggering issue creation each time it recurs.

## Out of scope

- Symbol-upload pipeline (already fixed in #138).
- Existing plugin call sites (`feedback_service.dart`, `in_app_update_service.dart`) — already wrapped with `onError`/try-catch.
- NDK/native symbol upload — separate, larger investigation.

## Validation

| Check | Result |
|-------|--------|
| `flutter analyze` | No issues found (ran in 7.4s) |
| `flutter test test/core/sentry_filters_test.dart` | 7 / 7 passed |
| `flutter test` (full suite) | 237 / 237 passed |

A release build was not run locally — it requires Android signing keys and `SENTRY_DSN` injected by CI. The change is exercised end-to-end by `flutter analyze` (validates compilation of the whole `lib/` tree) plus the unit tests.

## Test plan

- [ ] CI: `flutter analyze` passes
- [ ] CI: `flutter test` passes (237 tests)
- [ ] After release ships, confirm sentry-bridge no longer auto-creates duplicates of #145 (tracked by closing #145 once a build with this filter is in users' hands)