### PR TITLE
Test: pin ClientException variant for google_fonts filter

### DIFF
--- a/test/core/sentry_filters_test.dart
+++ b/test/core/sentry_filters_test.dart
@@ -203,6 +203,28 @@ void main() {
       expect(dropGoogleFontsFetchFailure(event, hint), isNull);
     });
 
+    // Pins the exact shape reported in issue #150: http.get catch path with
+    // a ClientException inner and a trailing `uri=` parameter. Differs from
+    // the SocketException test above only in the inner-exception type, but
+    // we want a regression anchor for this specific Sentry grouping.
+    test(
+        'drops event with ClientException inner ("Connection closed", trailing uri=)',
+        () {
+      final event = _eventWith(
+        value:
+            'Failed to load font with url https://fonts.gstatic.com/s/a/abc123.ttf: '
+            'ClientException: Connection closed before full header was received, '
+            'uri=https://fonts.gstatic.com/s/a/abc123.ttf',
+        frames: [
+          SentryStackFrame(
+            function: '_httpFetchFontAndSaveToDevice',
+            fileName: 'google_fonts_base.dart',
+          ),
+        ],
+      );
+      expect(dropGoogleFontsFetchFailure(event, hint), isNull);
+    });
+
     test('drops event when google_fonts_base.dart frame is not the top frame',
         () {
       final event = _eventWith(

--- a/test/core/sentry_filters_test.dart
+++ b/test/core/sentry_filters_test.dart
@@ -203,10 +203,9 @@ void main() {
       expect(dropGoogleFontsFetchFailure(event, hint), isNull);
     });
 
-    // Pins the exact shape reported in issue #150: http.get catch path with
-    // a ClientException inner and a trailing `uri=` parameter. Differs from
-    // the SocketException test above only in the inner-exception type, but
-    // we want a regression anchor for this specific Sentry grouping.
+    // Pins the http.get catch path: a ClientException inner with a trailing
+    // `uri=` parameter. This is its own Sentry grouping (distinct from the
+    // SocketException variant above), so we want an explicit regression anchor.
     test(
         'drops event with ClientException inner ("Connection closed", trailing uri=)',
         () {


### PR DESCRIPTION
## Summary

Adds a regression test pinning the exact Sentry exception shape reported in #150 — the `ClientException: Connection closed before full header was received, uri=…` variant of the google_fonts fetch failure. No production code changes; the existing `dropGoogleFontsFetchFailure` filter on `main` (introduced in #148) already drops this signature.

#150 was filed by sentry-bridge from a device running a pre-#148 binary (last release `release-2026-05-02` predates that merge). Verified the filter's substring (`Failed to load font with url`) and frame predicate (`google_fonts_base.dart`) match the reported event verbatim — it will suppress this signature once the next release ships. #150 was closed as a duplicate of #140 with an explanatory comment; this PR is the regression anchor so a future filter refactor can't silently re-open the signature.

## Changes

- `test/core/sentry_filters_test.dart` (+22 lines): new test inside the `dropGoogleFontsFetchFailure` group asserting the filter drops an event whose value is `Failed to load font with url <url>: ClientException: Connection closed before full header was received, uri=<url>` with a `_httpFetchFontAndSaveToDevice @ google_fonts_base.dart` top frame. Mirrors the existing SocketException-variant test at line 192 (same `_eventWith` helper, same single-frame shape).

No production code changed.

## Validation

- `flutter analyze` — ✅ No issues found (3.0s)
- `flutter test` — ✅ 270/270 passed (was 269; +1 new test)
  - New pass-line: `dropGoogleFontsFetchFailure drops event with ClientException inner ("Connection closed", trailing uri=)`
- `flutter build apk --debug` — ⚠️ skipped (local JDK 25.0.2 trips Kotlin tooling on this machine; reproduces on `main` too, not a regression. Test-only change with no Android code path.)

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test` — full suite green, new test included and passing
- [ ] Reviewer: confirm the new test sits inside the `dropGoogleFontsFetchFailure` group and uses the shared `_eventWith` helper (no duplicated test scaffolding)
- [ ] Reviewer: confirm no production code drift (diff should be `test/` only)

Fixes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)