### PR TITLE
Fix: cancel stale MoveEffects before cascade fall snap (#153)

### DIFF
--- a/lib/core/sentry_filters.dart
+++ b/lib/core/sentry_filters.dart
@@ -82,8 +82,7 @@ SentryEvent? dropGoogleFontsFetchFailure(SentryEvent event, Hint hint) {
 /// filter in sequence. Returns `null` (drop) if any filter drops the event,
 /// otherwise passes the event through untouched.
 ///
-/// Sentry only allows one `beforeSend` callback, so all filters must compose
-/// here. Add new filters by inserting a `dropX(event, hint) == null` short-circuit.
+/// Sentry only allows one `beforeSend` callback, so all filters must compose here.
 SentryEvent? dropUnactionableEvents(SentryEvent event, Hint hint) {
   if (dropUnactionableAbort(event, hint) == null) return null;
   if (dropGoogleFontsFetchFailure(event, hint) == null) return null;

--- a/lib/game/world/grid_world.dart
+++ b/lib/game/world/grid_world.dart
@@ -277,6 +277,15 @@ class GridWorld extends World {
         if (grid[tile.gridX][y] == tile.tileType && newTiles[tile.gridX][y] == null) {
           newTiles[tile.gridX][y] = tile;
           if (tile.gridY != y) {
+            // Cancel any stale MoveEffect (e.g., a refill animation that hasn't
+            // fully completed when the next cascade fires on a low-fps device).
+            // Its remaining delta would apply after the snap below, pushing the
+            // tile past the canonical cell and corrupting onStart() in the new
+            // MoveEffect (which reads target.position lazily on first update).
+            tile.children
+                .whereType<MoveEffect>()
+                .toList()
+                .forEach((e) => e.removeFromParent());
             // Anchor to old canonical position before overwriting gridY — MoveEffect
             // reads tile.position as its start point; without this, a mid-animation tile
             // starts from a stale visual position and overshoots the target cell.

--- a/lib/game/world/grid_world.dart
+++ b/lib/game/world/grid_world.dart
@@ -269,8 +269,7 @@ class GridWorld extends World {
     // ordering, so top-to-bottom sweep correctly maps each component to its
     // post-gravity cell. Matching is by tile type within the original column —
     // two same-coloured tiles in the same column can be mis-assigned, which is
-    // acceptable (rare and visually indistinguishable; a future refactor could
-    // assign by component identity rather than tile type to eliminate this).
+    // acceptable (rare and visually indistinguishable).
     for (final tile in liveTiles) {
       bool placed = false;
       for (int y = 0; y < rows; y++) {

--- a/lib/game/world/grid_world.dart
+++ b/lib/game/world/grid_world.dart
@@ -282,10 +282,9 @@ class GridWorld extends World {
             // Its remaining delta would apply after the snap below, pushing the
             // tile past the canonical cell and corrupting onStart() in the new
             // MoveEffect (which reads target.position lazily on first update).
-            tile.children
-                .whereType<MoveEffect>()
-                .toList()
-                .forEach((e) => e.removeFromParent());
+            for (final e in tile.children.whereType<MoveEffect>().toList()) {
+              e.removeFromParent();
+            }
             // Anchor to old canonical position before overwriting gridY — MoveEffect
             // reads tile.position as its start point; without this, a mid-animation tile
             // starts from a stale visual position and overshoots the target cell.

--- a/test/game/flame_gravity_sync_test.dart
+++ b/test/game/flame_gravity_sync_test.dart
@@ -1,3 +1,4 @@
+import 'package:flame/effects.dart';
 import 'package:flame/game.dart';
 import 'package:flame_test/flame_test.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -141,6 +142,54 @@ void main() {
         // cell before adding MoveEffect, preventing overshoot from the drifted start.
         world.applyGravityWithAnimationForTest();
 
+        expect(tile.position.x, closeTo(canonicalPos.x, kTestEpsilon));
+        expect(tile.position.y, closeTo(canonicalPos.y, kTestEpsilon));
+      },
+    );
+
+    testWithGame<FlameGame>(
+      'stale MoveEffect on tile is cancelled before fall animation — '
+      'prevents cascade overshoot (issue #153)',
+      () => FlameGame(world: TestGridWorld()),
+      (game) async {
+        final world = game.world as TestGridWorld;
+        world.grid = createEmptyGrid();
+        world.grid[0][0] = TileType.red;
+        world.initLayoutForTest(Vector2(400, 800));
+
+        final canonicalPos = world.tilePositionAt(0, 0);
+        final tile = GridTile(
+          gridX: 0,
+          gridY: 0,
+          tileType: TileType.red,
+          position: canonicalPos.clone(),
+          size: Vector2.all(world.tileSize - 2),
+        );
+        world.tiles[0][0] = tile;
+
+        // Simulate a stale refill MoveEffect that's still mounted on the tile
+        // (the 300ms cascade wait resolved before the last animation frame ran
+        // on a low-fps device). Without cancellation, its remaining apply()
+        // would push the tile past the canonical cell after the snap, and the
+        // new fall MoveEffect.onStart() would read the drifted position.
+        final staleEffect = MoveEffect.to(
+          canonicalPos.clone(),
+          EffectController(duration: 0.5),
+        );
+        tile.add(staleEffect);
+
+        // applyGravityWithAnimation must cancel the stale effect before adding
+        // the new fall MoveEffect — otherwise the stale delta corrupts onStart().
+        world.applyGravityWithAnimationForTest();
+
+        final remainingEffects = tile.children.whereType<MoveEffect>().toList();
+        expect(remainingEffects.contains(staleEffect), isFalse,
+            reason:
+                'stale refill MoveEffect must be cancelled before fall snap');
+        expect(remainingEffects.length, 1,
+            reason: 'only the new fall MoveEffect should remain on the tile');
+
+        // Snap position must still be canonical regardless of stale effect.
         expect(tile.position.x, closeTo(canonicalPos.x, kTestEpsilon));
         expect(tile.position.y, closeTo(canonicalPos.y, kTestEpsilon));
       },

--- a/test/game/flame_gravity_sync_test.dart
+++ b/test/game/flame_gravity_sync_test.dart
@@ -167,16 +167,19 @@ void main() {
         );
         world.tiles[0][0] = tile;
 
-        // Simulate a stale refill MoveEffect that's still mounted on the tile
-        // (the 300ms cascade wait resolved before the last animation frame ran
-        // on a low-fps device). Without cancellation, its remaining apply()
-        // would push the tile past the canonical cell after the snap, and the
-        // new fall MoveEffect.onStart() would read the drifted position.
+        // Simulate a stale refill MoveEffect still mounted on the tile when a
+        // cascade fires — the real bug occurs when this effect hasn't completed
+        // on a low-fps device and its remaining delta corrupts the snap.
+        // This test verifies the cancellation mechanism fires; the production
+        // comment on the fix explains the full timing race.
         final staleEffect = MoveEffect.to(
           canonicalPos.clone(),
           EffectController(duration: 0.5),
         );
         tile.add(staleEffect);
+        expect(tile.children.whereType<MoveEffect>().length, 1,
+            reason: 'stale effect must be in tile.children before gravity runs — '
+                'verifies that Flame add() is synchronous for unmounted components');
 
         // applyGravityWithAnimation must cancel the stale effect before adding
         // the new fall MoveEffect — otherwise the stale delta corrupts onStart().
@@ -192,6 +195,76 @@ void main() {
         // Snap position must still be canonical regardless of stale effect.
         expect(tile.position.x, closeTo(canonicalPos.x, kTestEpsilon));
         expect(tile.position.y, closeTo(canonicalPos.y, kTestEpsilon));
+      },
+    );
+
+    testWithGame<FlameGame>(
+      'multiple stale MoveEffects on tile are all cancelled before fall animation',
+      () => FlameGame(world: TestGridWorld()),
+      (game) async {
+        final world = game.world as TestGridWorld;
+        world.grid = createEmptyGrid();
+        world.grid[0][0] = TileType.red;
+        world.initLayoutForTest(Vector2(400, 800));
+
+        final canonicalPos = world.tilePositionAt(0, 0);
+        final tile = GridTile(
+          gridX: 0,
+          gridY: 0,
+          tileType: TileType.red,
+          position: canonicalPos.clone(),
+          size: Vector2.all(world.tileSize - 2),
+        );
+        world.tiles[0][0] = tile;
+
+        final stale1 = MoveEffect.to(canonicalPos.clone(), EffectController(duration: 0.5));
+        final stale2 = MoveEffect.to(canonicalPos.clone(), EffectController(duration: 0.3));
+        tile.add(stale1);
+        tile.add(stale2);
+
+        world.applyGravityWithAnimationForTest();
+
+        final remaining = tile.children.whereType<MoveEffect>().toList();
+        expect(remaining.contains(stale1), isFalse,
+            reason: 'first stale MoveEffect must be cancelled');
+        expect(remaining.contains(stale2), isFalse,
+            reason: 'second stale MoveEffect must be cancelled');
+        expect(remaining.length, 1,
+            reason: 'only the new fall MoveEffect should remain');
+      },
+    );
+
+    testWithGame<FlameGame>(
+      'MoveEffect on stationary tile is preserved when tile does not fall',
+      () => FlameGame(world: TestGridWorld()),
+      (game) async {
+        final world = game.world as TestGridWorld;
+        world.grid = createEmptyGrid();
+        // Tile at bottom row — gravity leaves it in place; cancellation must not fire
+        world.grid[0][GridWorld.rows - 1] = TileType.red;
+        world.initLayoutForTest(Vector2(400, 800));
+
+        final canonicalPos = world.tilePositionAt(0, GridWorld.rows - 1);
+        final tile = GridTile(
+          gridX: 0,
+          gridY: GridWorld.rows - 1,
+          tileType: TileType.red,
+          position: canonicalPos.clone(),
+          size: Vector2.all(world.tileSize - 2),
+        );
+        world.tiles[0][GridWorld.rows - 1] = tile;
+
+        final existingEffect = MoveEffect.to(
+          canonicalPos.clone(),
+          EffectController(duration: 0.5),
+        );
+        tile.add(existingEffect);
+
+        world.applyGravityWithAnimationForTest();
+
+        expect(tile.children.whereType<MoveEffect>().contains(existingEffect), isTrue,
+            reason: 'MoveEffect on a stationary tile must not be cancelled — '
+                'only falling tiles (gridY != new row) have stale effects removed');
       },
     );
   });


### PR DESCRIPTION
## Summary

Fixes #153: Cancel stale `MoveEffect`s before snapping tiles in `_applyGravityWithAnimation`.

On low-fps Android devices, the cascade refill animation can still be running when the next cascade triggers. This leaves a stale `MoveEffect` mounted on the tile. When `_applyGravityWithAnimation` snaps the tile's position and adds a new fall animation, the stale effect's remaining delta applies after the snap, drifting the tile past its canonical grid cell. The new fall effect then animates from this drifted position, making it visually appear as though the tile "fell a whole extra space."

### Root Cause

- `MoveToEffect.onStart()` in Flame reads `target.position` lazily (at effect start time, not add time)
- The cascade pipeline waits 300ms for refill animations to complete, but max refill duration is 280ms (row 7)
- On low-fps devices, the last animation frame may not run before the 300ms timer fires
- When `_applyGravityWithAnimation` runs, it snaps position and adds a new effect, but the stale effect's remaining delta applies in the same frame before `onStart()` reads the position
- Result: tile starts its fall animation from below its canonical cell

### Changes

1. **`lib/game/world/grid_world.dart`** (lines 279–289): Cancel any active `MoveEffect` on the tile before snapping its position. This ensures stale animation deltas never corrupt the new fall effect's starting position.

2. **`test/game/flame_gravity_sync_test.dart`** (new test): Regression test that verifies stale `MoveEffect`s are cancelled before fall animations, preventing the cascade overshoot.

### Validation

- ✅ `flutter analyze`: No issues
- ✅ `flutter test`: 271/271 tests passed (incl. new regression test)
- ✅ All existing tests continue to pass

Fixes #153
