### PR TITLE
Fix: reference issue #141 in google_fonts filter doc comment

### DIFF
--- a/lib/core/sentry_filters.dart
+++ b/lib/core/sentry_filters.dart
@@ -53,7 +53,7 @@ SentryEvent? dropUnactionableAbort(SentryEvent event, Hint hint) {
 /// These events are unactionable from app code: the maintainers themselves treat
 /// network failures as out of scope (google_fonts issue #534 closed "not planned").
 /// Dropping them here prevents sentry-bridge from re-filing the same GitHub issue
-/// every time a device hiccups (see issue #140).
+/// every time a device hiccups (see issues #140, #141).
 ///
 /// Match shape (all conditions required):
 ///   - exactly one exception in the event,


### PR DESCRIPTION
## Summary

Closes #141 by updating the doc comment in `lib/core/sentry_filters.dart` to reference both #140 and #141, confirming that the `dropGoogleFontsFetchFailure` filter already handles this exception shape.

## Investigation

Issue #141 filed on 2026-05-04 reported a google_fonts CDN fetch failure: `Exception: Failed to load font with url`. The fix was already deployed in PR #148 (merged 2026-05-05) via the `dropGoogleFontsFetchFailure` Sentry filter in `lib/core/sentry_filters.dart:66–79`. However, PR #148 only referenced issue #140, leaving #141 open despite being the same bug.

**Root cause**: No code defect — the filter already catches this exact exception shape. The `exception.value` contains `'Failed to load font with url'` regardless of obfuscation.

## Changes

**File**: `lib/core/sentry_filters.dart` (line 54–57)

- **Before**: `/// ... (see issue #140).`
- **After**: `/// ... (see issues #140, #141).`

This documents that both issues are covered by the same filter.

## Validation

- ✅ `flutter analyze` — No issues found
- ✅ `flutter test` — 273 passed, 0 failed
  - Sentry filter tests: 26 passed (includes `dropGoogleFontsFetchFailure` coverage)

Fixes #141