### PR TITLE
fix: address PR #165 review findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,8 +37,10 @@ lib/
                   #   sentry_filters.dart — `dropUnactionableEvents` composite beforeSend filter; delegates to
                   #     `dropUnactionableAbort` (#145, channel-buffer Abort) and
                   #     `dropGoogleFontsFetchFailure` (#140, google_fonts CDN fetch failures)
+                  #   crc_integrity.dart — `canonicalizeMap()` / `isValidCrc()` shared CRC utilities
   game/           # Flame game, FSM, world, components
                   #   Input/FSM enums (GamePhase, SwipeDirection) defined in match3_game.dart
+                  #   grid_logic.dart — pure grid-data operations (gravity, refill, swap); no Flame deps
     theme/        # Tile color palette constants (kTilePalette — derived from TileType.colorValue;
                   #   kTileGlowPalette — derived from TileType.glowValue, used for selection border;
                   #   kTileSelectedOverlay — transparent, selection drawn by _GlowBorder stroke;

--- a/package.json
+++ b/package.json
@@ -1,9 +1,0 @@
-{
-  "name": "cosmic-match",
-  "version": "1.0.0",
-  "scripts": {
-    "type-check": "flutter analyze",
-    "lint": "flutter analyze",
-    "test": "flutter test"
-  }
-}

--- a/test/core/crc_integrity_test.dart
+++ b/test/core/crc_integrity_test.dart
@@ -1,0 +1,54 @@
+import 'package:archive/archive.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cosmic_match/core/crc_integrity.dart';
+
+void main() {
+  group('canonicalizeMap', () {
+    test('sorts keys alphabetically', () {
+      final result = canonicalizeMap({'z': 1, 'a': 2, 'm': 3});
+      expect(result, 'a:2,m:3,z:1');
+    });
+
+    test('empty map returns empty string', () {
+      expect(canonicalizeMap({}), '');
+    });
+
+    test('single entry has no trailing comma', () {
+      expect(canonicalizeMap({'key': 'val'}), 'key:val');
+    });
+
+    test('is deterministic regardless of insertion order', () {
+      final a = canonicalizeMap({'x': 1, 'a': 2, 'b': 3});
+      final b = canonicalizeMap({'b': 3, 'x': 1, 'a': 2});
+      expect(a, b);
+    });
+  });
+
+  group('isValidCrc', () {
+    test('returns true for valid CRC', () {
+      final data = {'level': 1, 'score': 100};
+      final canon = canonicalizeMap(data);
+      final crc = getCrc32(canon.codeUnits);
+      final raw = {...data, 'crc': crc};
+      expect(isValidCrc(raw, canonicalize: canonicalizeMap), isTrue);
+    });
+
+    test('returns false when crc key is missing', () {
+      expect(
+          isValidCrc({'level': 1}, canonicalize: canonicalizeMap), isFalse);
+    });
+
+    test('returns false when data is tampered', () {
+      final data = {'level': 1, 'score': 100};
+      final canon = canonicalizeMap(data);
+      final crc = getCrc32(canon.codeUnits);
+      final raw = {'level': 1, 'score': 999, 'crc': crc};
+      expect(isValidCrc(raw, canonicalize: canonicalizeMap), isFalse);
+    });
+
+    test('returns false when crc value is null', () {
+      final raw = {'level': 1, 'crc': null};
+      expect(isValidCrc(raw, canonicalize: canonicalizeMap), isFalse);
+    });
+  });
+}

--- a/test/game/grid_logic_test.dart
+++ b/test/game/grid_logic_test.dart
@@ -1,0 +1,161 @@
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cosmic_match/game/grid_logic.dart';
+import 'package:cosmic_match/game/pattern_detector.dart';
+import 'package:cosmic_match/models/tile_type.dart';
+
+void main() {
+  group('GridLogic', () {
+    late GridLogic logic;
+
+    setUp(() {
+      logic = GridLogic(cols: 7, rows: 8, rng: Random(42));
+    });
+
+    group('initGrid', () {
+      test('produces a fully populated grid', () {
+        logic.initGrid(PatternDetector());
+        expect(logic.grid.length, 7);
+        for (int x = 0; x < 7; x++) {
+          expect(logic.grid[x].length, 8);
+          for (int y = 0; y < 8; y++) {
+            expect(logic.grid[x][y], isNotNull);
+          }
+        }
+      });
+
+      test('produces a grid with no initial matches', () {
+        final detector = PatternDetector();
+        logic.initGrid(detector);
+        expect(detector.detectAll(logic.grid), isEmpty);
+      });
+
+      test('respects grid dimensions', () {
+        final small = GridLogic(cols: 3, rows: 4, rng: Random(1));
+        small.initGrid(PatternDetector());
+        expect(small.grid.length, 3);
+        expect(small.grid[0].length, 4);
+      });
+    });
+
+    group('applyGravity', () {
+      test('moves tile down into null cell', () {
+        logic.grid = List.generate(7, (_) => List.generate(8, (_) => null));
+        logic.grid[0][5] = TileType.red;
+        // [0][6] and [0][7] are null — tile should fall one step
+        final moved = logic.applyGravity();
+        expect(moved, isTrue);
+        expect(logic.grid[0][5], isNull);
+        expect(logic.grid[0][6], TileType.red);
+      });
+
+      test('returns false when nothing moves', () {
+        logic.grid = List.generate(7, (_) => List.generate(8, (_) => null));
+        // Place tile at bottom row — nowhere to fall
+        logic.grid[0][7] = TileType.red;
+        expect(logic.applyGravity(), isFalse);
+      });
+
+      test('returns false on empty grid', () {
+        logic.grid = List.generate(7, (_) => List.generate(8, (_) => null));
+        expect(logic.applyGravity(), isFalse);
+      });
+
+      test('moves multiple tiles down in same column', () {
+        logic.grid = List.generate(7, (_) => List.generate(8, (_) => null));
+        logic.grid[2][3] = TileType.blue;
+        logic.grid[2][4] = TileType.red;
+        // [2][5], [2][6], [2][7] are null
+        logic.applyGravity();
+        // After one pass: each tile moves down by one
+        expect(logic.grid[2][4], TileType.blue);
+        expect(logic.grid[2][5], TileType.red);
+        expect(logic.grid[2][3], isNull);
+      });
+
+      test('tiles in different columns fall independently', () {
+        logic.grid = List.generate(7, (_) => List.generate(8, (_) => null));
+        logic.grid[0][0] = TileType.red;
+        logic.grid[3][0] = TileType.blue;
+        logic.applyGravity();
+        expect(logic.grid[0][1], TileType.red);
+        expect(logic.grid[3][1], TileType.blue);
+        expect(logic.grid[0][0], isNull);
+        expect(logic.grid[3][0], isNull);
+      });
+    });
+
+    group('refillTop', () {
+      test('fills only row 0 nulls', () {
+        logic.grid = List.generate(7, (_) => List.generate(8, (_) => null));
+        logic.refillTop();
+        for (int x = 0; x < 7; x++) {
+          expect(logic.grid[x][0], isNotNull);
+          for (int y = 1; y < 8; y++) {
+            expect(logic.grid[x][y], isNull);
+          }
+        }
+      });
+
+      test('does not overwrite existing tiles in row 0', () {
+        logic.grid = List.generate(7, (_) => List.generate(8, (_) => null));
+        logic.grid[0][0] = TileType.purple;
+        logic.refillTop();
+        expect(logic.grid[0][0], TileType.purple);
+      });
+    });
+
+    group('refillAll', () {
+      test('fills all null cells', () {
+        logic.grid = List.generate(7, (_) => List.generate(8, (_) => null));
+        logic.refillAll();
+        for (int x = 0; x < 7; x++) {
+          for (int y = 0; y < 8; y++) {
+            expect(logic.grid[x][y], isNotNull);
+          }
+        }
+      });
+
+      test('does not overwrite existing tiles', () {
+        logic.grid = List.generate(7, (_) => List.generate(8, (_) => null));
+        logic.grid[3][4] = TileType.yellow;
+        logic.refillAll();
+        expect(logic.grid[3][4], TileType.yellow);
+      });
+    });
+
+    group('swapTypes', () {
+      test('exchanges two tile types', () {
+        logic.grid = List.generate(7, (_) => List.generate(8, (_) => null));
+        logic.grid[0][0] = TileType.red;
+        logic.grid[1][0] = TileType.blue;
+        logic.swapTypes(0, 0, 1, 0);
+        expect(logic.grid[0][0], TileType.blue);
+        expect(logic.grid[1][0], TileType.red);
+      });
+
+      test('handles swap with null tile', () {
+        logic.grid = List.generate(7, (_) => List.generate(8, (_) => null));
+        logic.grid[0][0] = TileType.red;
+        logic.swapTypes(0, 0, 1, 0);
+        expect(logic.grid[0][0], isNull);
+        expect(logic.grid[1][0], TileType.red);
+      });
+
+      test('swap same position is a no-op', () {
+        logic.grid = List.generate(7, (_) => List.generate(8, (_) => null));
+        logic.grid[2][3] = TileType.orange;
+        logic.swapTypes(2, 3, 2, 3);
+        expect(logic.grid[2][3], TileType.orange);
+      });
+    });
+
+    group('randomTile', () {
+      test('returns a valid TileType', () {
+        final tile = logic.randomTile();
+        expect(TileType.values.contains(tile), isTrue);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Addresses review findings from PR #165 (refactor: simplify codebase with extracted utilities).

- Add 16 unit tests for `GridLogic` (`test/game/grid_logic_test.dart`) — covers `initGrid`, `applyGravity`, `refillTop`, `refillAll`, `swapTypes`, `randomTile`
- Add 8 unit tests for `crc_integrity` (`test/core/crc_integrity_test.dart`) — covers `canonicalizeMap`, `isValidCrc`
- Remove spurious `package.json` from Flutter project
- Update CLAUDE.md Project Layout with new extracted modules

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — 312 tests pass (24 new)
- [x] All new tests cover extracted pure-logic modules with no Flame dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)