### PR TITLE
Fix: remove GitHub API response body from logs (#179)

### DIFF
--- a/lib/services/feedback_queue_service.dart
+++ b/lib/services/feedback_queue_service.dart
@@ -93,9 +93,7 @@ class FeedbackQueueService {
           keysToDelete.add(key);
         }
       }
-      // Note: if an exception occurs mid-loop, `deleted` reflects a partial count
-      // (items deleted before the abort). The caller in main.dart discards the
-      // return value today; future callers should treat it as a best-effort count.
+      // deleted is a best-effort count; partial if an exception aborts mid-loop.
       for (final key in keysToDelete) {
         await box.delete(key);
         deleted++;

--- a/lib/services/feedback_service.dart
+++ b/lib/services/feedback_service.dart
@@ -124,9 +124,7 @@ class FeedbackService {
     }
   }
 
-  /// CRC32 integrity check (CLAUDE.md "CRC32 Persistence Contract"):
-  /// rejects any map missing a `crc` field or whose canonicalised payload
-  /// does not match the stored CRC.
+  // See CLAUDE.md "CRC32 Persistence Contract".
   bool _isValid(Map raw) =>
       isValidCrc(raw, canonicalize: PendingFeedback.canonicalize);
 

--- a/lib/services/github_feedback_client.dart
+++ b/lib/services/github_feedback_client.dart
@@ -109,10 +109,8 @@ class GitHubFeedbackClient {
     required String label,
   }) {
     if (response.statusCode < 200 || response.statusCode >= 300) {
-      final snippet =
-          response.body.substring(0, response.body.length.clamp(0, 200));
-      gameLogger.e(
-          'GitHubFeedbackClient.$method failed: ${response.statusCode} — $snippet');
+      gameLogger.w(
+          'GitHubFeedbackClient.$method failed: HTTP ${response.statusCode}');
       throw FeedbackClientException(
           '$label failed with status ${response.statusCode}');
     }

--- a/test/services/github_feedback_client_test.dart
+++ b/test/services/github_feedback_client_test.dart
@@ -193,7 +193,7 @@ void main() {
       );
     });
 
-    test('_throwIfError throws on 500 with body longer than 200 chars', () async {
+    test('_throwIfError throws on 500 regardless of body length', () async {
       final longBody = 'x' * 300;
       final mockHttp = MockClient((_) async => http.Response(longBody, 500));
 
@@ -204,6 +204,21 @@ void main() {
           (e) => e.message,
           'message',
           contains('500'),
+        )),
+      );
+    });
+
+    test('_throwIfError does not include response body in exception message', () async {
+      const sensitiveBody = '{"token":"ghp_secret_value","message":"Bad credentials"}';
+      final mockHttp = MockClient((_) async => http.Response(sensitiveBody, 403));
+
+      final client = GitHubFeedbackClient.withToken('ghp_test', httpClient: mockHttp);
+      await expectLater(
+        () => client.uploadImage('img-1', _minimalPng),
+        throwsA(isA<FeedbackClientException>().having(
+          (e) => e.message,
+          'message',
+          isNot(contains('ghp_secret_value')),
         )),
       );
     });

--- a/test/services/github_feedback_client_test.dart
+++ b/test/services/github_feedback_client_test.dart
@@ -223,6 +223,21 @@ void main() {
       );
     });
 
+    test('_throwIfError does not include response body in createIssue exception message', () async {
+      const sensitiveBody = '{"token":"ghp_secret_value","message":"Bad credentials"}';
+      final mockHttp = MockClient((_) async => http.Response(sensitiveBody, 403));
+
+      final client = GitHubFeedbackClient.withToken('ghp_test', httpClient: mockHttp);
+      await expectLater(
+        () => client.createIssue('desc', 'https://img.png'),
+        throwsA(isA<FeedbackClientException>().having(
+          (e) => e.message,
+          'message',
+          isNot(contains('ghp_secret_value')),
+        )),
+      );
+    });
+
     test('uploadImage sends correct request body structure', () async {
       Map<String, dynamic>? capturedBody;
       final mockHttp = MockClient((request) async {


### PR DESCRIPTION
## Summary

Removes sensitive GitHub API response body logging from `GitHubFeedbackClient._throwIfError()`. The method previously logged up to 200 characters of the raw HTTP response body at error level, which could expose API state, rate-limit headers, or token-related details.

## Changes

### `lib/services/github_feedback_client.dart`
- Replace body-snippet logging with status-code-only warning
- Change log level from `.e` (error) to `.w` (warning) — HTTP 4xx/5xx from remote API is not an internal app error
- Remove unused `snippet` variable

### `test/services/github_feedback_client_test.dart`
- Rename test `_throwIfError throws on 500 with body longer than 200 chars` → `_throwIfError throws on 500 regardless of body length`
- Add new test: `_throwIfError does not include response body in exception message` — ensures sensitive content (e.g., token errors) cannot be extracted from the thrown exception

## Validation

- **flutter analyze**: ✅ No issues found
- **flutter test**: ✅ All 324 tests passed
- No files modified during validation

## Security Impact

- **Severity**: LOW (code path inactive in production without `GITHUB_FEEDBACK_TOKEN` compile-time flag)
- **Coverage**: Blocks information leakage from HTTP error responses

Fixes #179