### PR TITLE
Fix: truncate verbose device fingerprint in feedback payload

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -187,7 +187,7 @@ class _CosmicMatchAppState extends State<CosmicMatchApp> {
           screenshotB64: screenshotB64,
           appVersion: '${packageInfo.version}+${packageInfo.buildNumber}',
           os: Platform.operatingSystem,
-          device: Platform.operatingSystemVersion,
+          device: Platform.operatingSystemVersion.split(' ').first,
         );
       },
     );

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -8,7 +8,13 @@ class HomeScreen extends StatelessWidget {
   final VoidCallback onFeedback;
   final VoidCallback onClearFeedbackQueue;
 
-  const HomeScreen({super.key, required this.onPlay, required this.onMap, required this.onFeedback, required this.onClearFeedbackQueue});
+  const HomeScreen({
+    super.key,
+    required this.onPlay,
+    required this.onMap,
+    required this.onFeedback,
+    required this.onClearFeedbackQueue,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -203,11 +209,13 @@ class HomeScreen extends StatelessWidget {
                               'This will permanently delete all unsent feedback.'),
                           actions: [
                             TextButton(
-                                onPressed: () => Navigator.pop(ctx, false),
-                                child: const Text('Cancel')),
+                              onPressed: () => Navigator.pop(ctx, false),
+                              child: const Text('Cancel'),
+                            ),
                             TextButton(
-                                onPressed: () => Navigator.pop(ctx, true),
-                                child: const Text('Clear')),
+                              onPressed: () => Navigator.pop(ctx, true),
+                              child: const Text('Clear'),
+                            ),
                           ],
                         ),
                       );

--- a/lib/widgets/hud_overlay.dart
+++ b/lib/widgets/hud_overlay.dart
@@ -67,7 +67,7 @@ class HudOverlay extends StatelessWidget {
           screenshotB64: screenshotB64,
           appVersion: '${packageInfo.version}+${packageInfo.buildNumber}',
           os: Platform.operatingSystem,
-          device: Platform.operatingSystemVersion,
+          device: Platform.operatingSystemVersion.split(' ').first,
         );
       },
     );


### PR DESCRIPTION
## Summary

Fixes #178

Truncates `Platform.operatingSystemVersion` to the first space-delimited token when constructing the feedback payload, preventing overly verbose device identification (kernel version, build fingerprint, device codename) from being sent to the server.

## Problem

The app was sending the full `Platform.operatingSystemVersion` value as the `device` field in feedback payloads. On Android, this includes sensitive details like:
- Kernel version (e.g. `5.10.0-12345`)
- Build fingerprint
- Device codename

This granular fingerprinting data is unnecessary for bug triage and creates a security risk by exposing device identification in server logs and potentially in GitHub issues.

## Solution

Changed two call sites to truncate the version string to its first token:
- `lib/main.dart:190`: Truncate when creating feedback for screenshot capture
- `lib/widgets/hud_overlay.dart:70`: Truncate when creating feedback from HUD overlay

Now only the leading token (e.g. `"Linux"` or `"Android"`) is sent, providing sufficient OS info for triage without exposing build details.

## Changes

| File | Change |
|------|--------|
| `lib/main.dart` | Truncate `Platform.operatingSystemVersion` to first token |
| `lib/widgets/hud_overlay.dart` | Truncate `Platform.operatingSystemVersion` to first token |

**Pattern**: `Platform.operatingSystemVersion.split(' ').first`

## Validation

- ✅ `flutter analyze`: No issues
- ✅ `flutter test`: All 325 tests pass
- ✅ Existing feedback tests unaffected (use hardcoded device values)

## Risk Assessment

- **Severity**: Low — cosmetic over-sharing, no data leakage beyond logs
- **Complexity**: Low — two identical one-line changes
- **Backward Compatibility**: Acceptable — fix only affects new submissions; existing queued items in Hive unaffected