### PR TITLE
Fix: isolate integration tests with matrix strategy

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,9 +12,13 @@ permissions:
 
 jobs:
   integration:
-    name: Integration Tests
+    name: Integration Tests (${{ matrix.test }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      matrix:
+        test: [integration_test/app_boot_test.dart, integration_test/scripted_match_test.dart]
+      fail-fast: false
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -44,4 +48,4 @@ jobs:
           api-level: 34
           target: google_apis
           arch: x86_64
-          script: flutter test integration_test/
+          script: flutter test ${{ matrix.test }}

--- a/integration_test/scripted_match_test.dart
+++ b/integration_test/scripted_match_test.dart
@@ -49,6 +49,7 @@ void main() {
   });
 
   tearDown(() async {
+    game.pauseEngine(); // Stop Flame game loop before Hive shutdown to avoid async write race
     await Hive.close();
     await tempDir.delete(recursive: true);
   });


### PR DESCRIPTION
## Summary

Fixes the broken CI pipeline where integration tests fail due to the emulator crashing after `scripted_match_test.dart` completes. The native `in_app_update` Play Core library crashes on the `google_apis` emulator (which lacks Google Play Store), and the Flame game loop may race with `Hive.close()` in tearDown. Both factors take down the emulator before `app_boot_test.dart` can run.

## Changes

### `.github/workflows/integration.yml`
- Added matrix strategy to run each integration test in its own fresh emulator
- Each test file (`app_boot_test.dart`, `scripted_match_test.dart`) now runs in parallel with `fail-fast: false` to ensure both report results
- Updated the script parameter to use `${{ matrix.test }}` instead of running all tests in a single emulator

**Why**: Isolating tests prevents emulator crashes from blocking subsequent tests. If `scripted_match_test.dart` crashes the emulator, `app_boot_test.dart` is unaffected.

### `integration_test/scripted_match_test.dart`
- Added `game.pauseEngine()` before `Hive.close()` in tearDown
- This stops the Flame game loop (60 Hz ticker) before database shutdown

**Why**: Prevents async `GridWorld._persistScore()` Hive writes from racing with `Hive.close()`, eliminating one factor that can crash the emulator.

## Validation

✅ `flutter analyze` — No issues found
✅ `flutter test` — 325 passed, 0 failed
✅ All changes match the investigation findings

## Fixes

Fixes #187